### PR TITLE
feat(repo): add core project docs and bootstrap script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# SpetraMindV50
-Use AI to clear up noisy satilite data in order to find exoplanets.
+# SpectraMind V50
+
+SpectraMind V50 is our entry for the NeurIPS 2025 Ariel Data Challenge. The goal is to use AI to clear noisy satellite spectral data to identify exoplanets.
+
+## Getting Started
+Run the bootstrap script to set up dependencies.
+
+```bash
+./scripts/bootstrap_spectramind_v50.sh
+```
+
+## Architecture
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for the full technical blueprint.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,17 @@
+# SpectraMind V50 Architecture
+
+This document outlines the technical blueprint for the SpectraMind V50 project.
+
+## Overview
+The system processes raw spectral data from the Ariel satellite, denoises it, and detects exoplanet signals.
+
+## Components
+- **data ingestion**: downloads and formats raw datasets.
+- **preprocessing**: applies calibration and noise reduction.
+- **modeling**: trains deep learning models to detect planetary signatures.
+- **evaluation**: assesses performance using challenge metrics.
+
+## Repository Layout
+- `README.md` – project overview.
+- `docs/ARCHITECTURE.md` – this blueprint.
+- `scripts/bootstrap_spectramind_v50.sh` – one-command setup script.

--- a/scripts/bootstrap_spectramind_v50.sh
+++ b/scripts/bootstrap_spectramind_v50.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+echo "Bootstrapping SpectraMind V50 environment..."
+
+python3 -m venv .venv
+source .venv/bin/activate
+
+pip install --upgrade pip
+# pip install -r requirements.txt
+
+echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- replace minimal README with SpectraMind V50 overview and quickstart
- add docs/ARCHITECTURE.md as the technical blueprint
- add scripts/bootstrap_spectramind_v50.sh to bootstrap the environment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689972848684832ab95a5f153ef67713