### PR TITLE
docs: add operator quick reference (USAGE.md) for local & Kaggle modes

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,28 @@
+# Operator Quick Reference
+
+A cheat sheet for operating SpectraMind locally and on Kaggle.
+
+## Local mode
+- Install dependencies and activate the environment.
+- Run training:
+  ```bash
+  python -m spectramind train
+  ```
+- Perform calibration and diagnostics:
+  ```bash
+  python -m spectramind calibrate-temp
+  python -m spectramind diagnose
+  ```
+- Create a submission bundle:
+  ```bash
+  python -m spectramind submit bundle
+  ```
+
+## Kaggle mode
+- Use the Kaggle runtime and data paths (e.g. `/kaggle/input` and `/kaggle/working`).
+- Select the `data=kaggle` config override when invoking the CLI.
+- Typical prediction entry point:
+  ```bash
+  python -m spectramind predict --out-csv /kaggle/working/submission.csv
+  ```
+- Keep the total runtime under Kaggle's 9‑hour limit.


### PR DESCRIPTION
## Summary
- add operator quick reference docs/USAGE.md for local and Kaggle modes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a176b5350832a8da6aac5efc6b2fd