### PR TITLE
docs: expand AIRS GNN usage

### DIFF
--- a/configs/model/airs_gnn/README.md
+++ b/configs/model/airs_gnn/README.md
@@ -1,16 +1,40 @@
-# /configs/model/airs_gnn
+# AIRS GNN Config Set (Hydra-ready)
 
-Hydra YAML configs for the **AIRS physics‑informed GNN encoder** (283 spectral bins as nodes).
-These override only `model.encoders.airs_gnn` so you can tune the spectral graph stack without
-touching fusion, decoders, or FGS1.
+This directory contains Hydra component configs for the **AIRS spectral graph encoder** used by SpectraMind V50.
+They’re designed to be composed under the root `config_v50.yaml` via `model.encoders.airs_gnn`.
 
-## Usage
+Highlights:
+- Physics-informed graph: edges from wavelength adjacency, molecule bands, and detector seams.
+- Edge features: Δλ, molecule tags, seam flags; optional learnable encodings.
+- Attention-friendly backends: GAT (default), plus RGCN and NNConv flavors.
+- TorchScript/JIT-safe model contracts, dropout, residuals, and attention export toggles.
+- Size presets: `tiny`, `small`, `medium`, `large` for quick runtime control (Kaggle ≤9h guardrail).
 
-Override just the AIRS encoder from the CLI:
+## How to use (examples)
+
+Default (GAT, medium):
+
 ```bash
-python -m spectramind train model.airs_gnn=base
-python -m spectramind train model.airs_gnn=small
 python -m spectramind train model.airs_gnn=medium
-python -m spectramind train model.airs_gnn=large
-# Optional: swap edge/PE/explainability options
-python -m spectramind train model.airs_gnn=base model.airs_gnn@model.encoders.airs_gnn.edges=edges
+```
+
+RGCN variant:
+
+```bash
+python -m spectramind train model.airs_gnn=medium model.airs_gnn@model.encoders.airs_gnn.backend=rgcn
+```
+
+Custom preset override:
+
+```bash
+python -m spectramind train model.airs_gnn=small model.encoders.airs_gnn.hidden_dim=256 model.encoders.airs_gnn.n_layers=4
+```
+
+## Size presets
+
+| preset | hidden_dim | n_layers | heads | dropout |
+|--------|------------|----------|-------|---------|
+| small  | 128        | 2        | 2     | 0.05    |
+| medium | 192        | 3        | 4     | 0.10    |
+
+*Tiny and large presets will be documented when available.*


### PR DESCRIPTION
## Summary
- expand AIRS GNN README with RGCN backend example and custom preset override
- document small and medium size presets in a table

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689ca6fc7bd4832a9e83702a3d929009