### PR TITLE
Align Hydra data config overrides

### DIFF
--- a/configs/data/README.md
+++ b/configs/data/README.md
@@ -1,22 +1,20 @@
 # SpectraMind V50 — `configs/data` Pack
 
-This directory defines the Hydra‑safe, environment‑portable data configuration used across the CLI:
+This directory defines the Hydra-safe, environment-portable data configuration used across the CLI:
 
-- `base.yaml` — canonical defaults for paths, IO, loader, splits, calibration, features, instruments, diagnostics.  
-- `local.yaml` — workstation overrides (paths under `_local/`, more workers).  
-- `kaggle.yaml` — Kaggle runtime guardrails (fewer workers, working paths).  
-- `splits.yaml` — GroupKFold materialization controls (file output, quick‑dev slice).  
-- `calibration.yaml` — tuning knobs for each calibration kill‑chain stage.  
-- `fgs1.yaml` — FGS1 instrument‑specific feature & extraction settings.  
-- `airs.yaml` — AIRS instrument‑specific spectral feature settings.  
-- `features.yaml` — persisted NPZ key schemas and toggles for fgs1_white / airs_bins.  
-- `paths.yaml` — skeleton of directories the CLI can pre‑create for you.  
-- `schema.yaml` — runtime schemas for validators and integrity checks.  
-- `dev_fast.yaml` — developer quick‑iterate configuration.
+- **base.yaml** — canonical defaults for paths, IO, loader, splits, calibration, features, instruments, diagnostics.  
+- **local.yaml** — workstation overrides (paths under `_local/`, more workers).  
+- **kaggle.yaml** — Kaggle runtime guardrails (fewer workers, working paths).  
+- **splits.yaml** — GroupKFold materialization controls (file output, quick-dev slice).  
+- **calibration.yaml** — tuning knobs for each calibration kill-chain stage.  
+- **fgs1.yaml** — FGS1 instrument-specific feature & extraction settings.  
+- **airs.yaml** — AIRS instrument-specific spectral feature settings.  
+- **features.yaml** — persisted NPZ key schemas and toggles for `fgs1_white` / `airs_bins`.  
+- **paths.yaml** — skeleton of directories the CLI can pre-create for you.  
+- **schema.yaml** — runtime schemas for validators and integrity checks.  
+- **dev_fast.yaml** — developer quick-iterate configuration.
 
 ### Composition examples
-
-Use via `config_v50.yaml` defaults or CLI overrides:
 
 ```bash
 # Use base + local overrides
@@ -27,4 +25,4 @@ python -m spectramind diagnose +data=@configs/data/base.yaml +data=@configs/data
 
 # Explicit split materialization
 python -m spectramind prepare-splits +data=@configs/data/base.yaml +data=@configs/data/splits.yaml
-``` 
+```

--- a/configs/data/dev_fast.yaml
+++ b/configs/data/dev_fast.yaml
@@ -1,6 +1,6 @@
 # configs/data/dev_fast.yaml
 # Developer quick path — smallest safe settings for rapid iteration.
-@package global
+@package _global_
 
 data:
   loader:

--- a/configs/data/kaggle.yaml
+++ b/configs/data/kaggle.yaml
@@ -1,7 +1,7 @@
 # configs/data/kaggle.yaml
-# Kaggle runtime guardrails — fewer workers, reduced IO overhead, explicit paths.
+# Kaggle runtime guardrails — fewer workers, reduced IO overhead, explicit container paths.
 
-@package global
+@package _global_
 
 data:
   paths:
@@ -31,7 +31,7 @@ data:
       integrity_check: true
     dvc_track: false
     mmap:
-      enabled: false     # kaggle FS often slower for mmap
+      enabled: false        # Kaggle FS often slower for mmap
     telemetry:
       log_open_close: false
       log_io_stats: true

--- a/configs/data/local.yaml
+++ b/configs/data/local.yaml
@@ -1,6 +1,6 @@
 # configs/data/local.yaml
 # Workstation override for paths, IO parallelism, and caching.
-@package global
+@package _global_
 
 data:
   paths:

--- a/configs/data/schema.yaml
+++ b/configs/data/schema.yaml
@@ -3,9 +3,18 @@
 
 data:
   schema:
-    calibrated_npz_required: ["frames", "variance", "mask"]
-    fgs1_white_npz_required: ["flux", "time", "centroid", "jitter"]
-    airs_bins_npz_required:  ["flux", "time"]
+    calibrated_npz_required:
+      - frames
+      - variance
+      - mask
+    fgs1_white_npz_required:
+      - flux
+      - time
+      - centroid
+      - jitter
+    airs_bins_npz_required:
+      - flux
+      - time
 
     # Optional sidecar JSON keys
     fgs1_white_sidecar:


### PR DESCRIPTION
## Summary
- ensure Hydra config overrides use `@package _global_` across data pack templates
- clarify Kaggle and dev_fast configs and expand schema lists
- refresh data config README with bold file descriptions and usage examples

## Testing
- `pytest tests/test_fusion.py` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_689cac7472a8832a8f5fc7396c24fbc8