### PR TITLE
feat(configs): add sigma_head configuration suite

### DIFF
--- a/configs/model/sigma_head/README.md
+++ b/configs/model/sigma_head/README.md
@@ -1,0 +1,69 @@
+configs/model/sigma_head/ — Uncertainty Head Config Suite (SpectraMind V50)
+
+This directory contains Hydra-safe, mission-grade configuration presets for the σ (uncertainty) decoder head of SpectraMind V50. Each file composes under model.decoders.sigma_head and aligns with our neuro-symbolic, physics-informed pipeline, Kaggle runtime guardrails, and diagnostics dashboard.
+
+Files
+• base.yaml — Canonical defaults; safe starting point for most runs.
+• gaussian.yaml — Heteroscedastic Gaussian σ head (fast, baseline-strong).
+• flow.yaml — Flow-based σ head with attention × symbolic fusion (most expressive).
+• evidential.yaml — Normal-Inverse-Gamma evidential uncertainty (calibration-friendly).
+• quantile.yaml — Quantile regression head (pinball loss, robust tails).
+• ensemble.yaml — Deep-ensemble aggregation policy for σ fusion.
+• calibration.yaml — Temperature scaling, COREL GNN, and Conformal Prediction controls.
+• kaggle.yaml — Runtime-aware overrides for 9-hour constraint.
+• leaderboard.yaml — Tuned for peak leaderboard stability/calibration.
+• debug.yaml — Verbose logging/exports for diagnostics dashboard.
+
+Common Schema
+
+All heads share a common envelope:
+
+model:
+  decoders:
+    sigma_head:
+      kind: <gaussian|flow|evidential|quantile|ensemble>
+      in_features: 256            # match your decoder neck
+      hidden_features: 256
+      num_layers: 4
+      dropout: 0.10
+      activation: "gelu"          # ["relu","gelu","silu"]
+      init: "kaiming_uniform"     # ["kaiming_uniform","xavier_uniform"]
+      output:
+        min_sigma: 1.0e-05
+        max_sigma: 1.0
+      fusion:
+        enable_attention_fuse: false
+        attention_heads: 4
+        symbolic_overlay_weight: 0.0
+      calibration:
+        enable: false
+        method: "none"            # ["none","temperature","corel","conformal"]
+
+Additional per-head blocks (e.g., flow:, evidential:, quantile:) are defined in their respective files.
+
+Usage
+
+Compose with Hydra:
+• Flow head + COREL:
+    - model/sigma_head=flow
+    - model/sigma_head=calibration
+
+• Gaussian head + temperature scaling:
+    - model/sigma_head=gaussian
+    - model/sigma_head=calibration
+
+• Evidential head + conformal fallback (held-out):
+    - model/sigma_head=evidential
+    - model/sigma_head=calibration
+
+• Kaggle lean:
+    - model/sigma_head=kaggle
+
+• Leaderboard:
+    - model/sigma_head=leaderboard
+
+Notes
+• fusion.symbolic_overlay_weight blends symbolic diagnostics (e.g., rule violations) into σ estimation attention fusion for informed uncertainty inflation around suspect bins/regions.
+• calibration.corel assumes availability of your SpectralCOREL module (binwise, edge-aware GNN) and its dataset split handling.
+• The conformal section uses per-bin or grouped quantile calibration compatible with your spectral_conformal.py.
+• output.min_sigma prevents numerically tiny variances; ensure your loss (GLL) clamps/log-transforms consistently.

--- a/configs/model/sigma_head/base.yaml
+++ b/configs/model/sigma_head/base.yaml
@@ -1,0 +1,52 @@
+# Canonical Sigma Head defaults (Hydra-safe)
+
+model:
+  decoders:
+    sigma_head:
+      kind: "gaussian"          # ["gaussian","flow","evidential","quantile","ensemble"]
+      in_features: 256
+      hidden_features: 256
+      num_layers: 4
+      dropout: 0.10
+      activation: "gelu"        # ["relu","gelu","silu"]
+      init: "kaiming_uniform"   # ["kaiming_uniform","xavier_uniform","lecun_normal"]
+      output:
+        min_sigma: 1.0e-05
+        max_sigma: 1.0
+        clamp_strategy: "hard"  # ["none","hard","softplus"]
+      fusion:
+        enable_attention_fuse: false
+        attention_heads: 4
+        attention_dropout: 0.10
+        symbolic_overlay_weight: 0.0   # 0.0 = off; 0.05-0.2 typical
+        export_attention_weights: false
+      logging:
+        export_sigma_hist: true
+        export_calibration_plots: true
+        export_per_bin_csv: true
+      calibration:
+        enable: false
+        method: "none"          # ["none","temperature","corel","conformal"]
+        temperature:
+          init_t: 1.0
+          learn_t: false
+        corel:
+          enabled: false
+          ckpt: null
+          binwise: true
+          graph:
+            use_edge_features: true
+            edge_types: ["distance","molecule","detector_region"]
+          training:
+            epochs: 10
+            lr: 1.0e-3
+            weight_decay: 1.0e-4
+            batch_size: 64
+            coverage_target: 0.6827
+            coverage_tolerance: 0.01
+        conformal:
+          enabled: false
+          mode: "binwise"       # ["binwise","molecule_grouped"]
+          quantile: 0.6827
+          calibration_split: "val"
+          jitter_epsilon: 1.0e-6

--- a/configs/model/sigma_head/calibration.yaml
+++ b/configs/model/sigma_head/calibration.yaml
@@ -1,0 +1,31 @@
+# Uncertainty calibration controls (compose after a head)
+
+model:
+  decoders:
+    sigma_head:
+      calibration:
+        enable: true
+        method: "corel"            # ["none","temperature","corel","conformal"]
+        temperature:
+          init_t: 1.0
+          learn_t: true
+        corel:
+          enabled: true
+          ckpt: null
+          binwise: true
+          graph:
+            use_edge_features: true
+            edge_types: ["distance","molecule","detector_region"]
+          training:
+            epochs: 10
+            lr: 1.0e-3
+            weight_decay: 1.0e-4
+            batch_size: 64
+            coverage_target: 0.6827
+            coverage_tolerance: 0.01
+        conformal:
+          enabled: false
+          mode: "binwise"          # ["binwise","molecule_grouped"]
+          quantile: 0.6827
+          calibration_split: "val"
+          jitter_epsilon: 1.0e-6

--- a/configs/model/sigma_head/debug.yaml
+++ b/configs/model/sigma_head/debug.yaml
@@ -1,0 +1,17 @@
+# Verbose exports for diagnostics dashboard & CI self-test visibility
+
+model:
+  decoders:
+    sigma_head:
+      logging:
+        export_sigma_hist: true
+        export_calibration_plots: true
+        export_per_bin_csv: true
+      fusion:
+        export_attention_weights: true
+      calibration:
+        enable: true
+        method: "temperature"
+        temperature:
+          init_t: 1.0
+          learn_t: true

--- a/configs/model/sigma_head/ensemble.yaml
+++ b/configs/model/sigma_head/ensemble.yaml
@@ -1,0 +1,42 @@
+# Deep ensemble policy for σ fusion
+# Assumes multiple trained heads or checkpoints available.
+
+model:
+  decoders:
+    sigma_head:
+      kind: "ensemble"
+      ensemble:
+        members: 5                  # number of heads/models
+        reduce: "var"               # ["var","mean","median","quantile"]
+        jackknife_plus: false
+        diversity_weight: 0.0       # optional diversity regularization at train time
+      in_features: 256
+      hidden_features: 256
+      num_layers: 3
+      dropout: 0.05
+      activation: "silu"
+      init: "kaiming_uniform"
+      output:
+        min_sigma: 1.0e-05
+        max_sigma: 0.8
+        clamp_strategy: "softplus"
+      fusion:
+        enable_attention_fuse: false
+        symbolic_overlay_weight: 0.0
+      calibration:
+        enable: true
+        method: "corel"
+        corel:
+          enabled: true
+          ckpt: null
+          binwise: true
+          graph:
+            use_edge_features: true
+            edge_types: ["distance","molecule","detector_region"]
+          training:
+            epochs: 8
+            lr: 1.0e-3
+            weight_decay: 1.0e-4
+            batch_size: 64
+            coverage_target: 0.6827
+            coverage_tolerance: 0.015

--- a/configs/model/sigma_head/evidential.yaml
+++ b/configs/model/sigma_head/evidential.yaml
@@ -1,0 +1,39 @@
+# Evidential uncertainty (Normal-Inverse-Gamma)
+# Produces (mu, v, alpha, beta) with closed-form aleatoric/epistemic proxies.
+
+model:
+  decoders:
+    sigma_head:
+      kind: "evidential"
+      in_features: 256
+      hidden_features: 256
+      num_layers: 4
+      dropout: 0.10
+      activation: "gelu"
+      init: "kaiming_uniform"
+      evidential:
+        min_alpha: 1.0 + 1.0e-3
+        min_v: 1.0e-3
+        min_beta: 1.0e-6
+        prior_strength: 1.0
+        regularizer:
+          enable: true
+          lambda_evi: 1.0e-3   # evidential penalty weight
+      output:
+        min_sigma: 1.0e-05
+        max_sigma: 0.9
+        clamp_strategy: "softplus"
+      fusion:
+        enable_attention_fuse: true
+        attention_heads: 2
+        attention_dropout: 0.10
+        symbolic_overlay_weight: 0.08
+      calibration:
+        enable: true
+        method: "conformal"
+        conformal:
+          enabled: true
+          mode: "binwise"
+          quantile: 0.6827
+          calibration_split: "val"
+          jitter_epsilon: 1.0e-6

--- a/configs/model/sigma_head/gaussian.yaml
+++ b/configs/model/sigma_head/gaussian.yaml
@@ -1,0 +1,25 @@
+# Heteroscedastic Gaussian σ head (fast, strong baseline)
+
+model:
+  decoders:
+    sigma_head:
+      kind: "gaussian"
+      in_features: 256
+      hidden_features: 256
+      num_layers: 3
+      dropout: 0.05
+      activation: "silu"
+      init: "kaiming_uniform"
+      output:
+        min_sigma: 1.0e-05
+        max_sigma: 0.5
+        clamp_strategy: "softplus"   # smooth, avoids zero
+      fusion:
+        enable_attention_fuse: false
+        symbolic_overlay_weight: 0.0
+      calibration:
+        enable: true
+        method: "temperature"
+        temperature:
+          init_t: 1.0
+          learn_t: true

--- a/configs/model/sigma_head/kaggle.yaml
+++ b/configs/model/sigma_head/kaggle.yaml
@@ -1,0 +1,30 @@
+# Kaggle/runtime-lean overrides for the 9-hour guardrail
+# Use simpler head + temperature scaling; disable heavy exports.
+
+model:
+  decoders:
+    sigma_head:
+      kind: "gaussian"
+      in_features: 256
+      hidden_features: 192
+      num_layers: 2
+      dropout: 0.05
+      activation: "relu"
+      init: "kaiming_uniform"
+      output:
+        min_sigma: 1.0e-05
+        max_sigma: 0.6
+        clamp_strategy: "softplus"
+      fusion:
+        enable_attention_fuse: false
+        symbolic_overlay_weight: 0.0
+      logging:
+        export_sigma_hist: false
+        export_calibration_plots: false
+        export_per_bin_csv: false
+      calibration:
+        enable: true
+        method: "temperature"
+        temperature:
+          init_t: 1.0
+          learn_t: true

--- a/configs/model/sigma_head/leaderboard.yaml
+++ b/configs/model/sigma_head/leaderboard.yaml
@@ -1,5 +1,4 @@
-# Flow-based σ head with attention × symbolic fusion
-# Expects FlowUncertaintyHead in codebase with MAF/RQ-Coupling support.
+# Leaderboard-oriented σ config: stable, well-calibrated, mild fusion
 
 model:
   decoders:
@@ -13,17 +12,17 @@ model:
       init: "xavier_uniform"
       output:
         min_sigma: 1.0e-05
-        max_sigma: 0.8
+        max_sigma: 0.7
         clamp_strategy: "softplus"
       fusion:
         enable_attention_fuse: true
         attention_heads: 4
         attention_dropout: 0.10
-        export_attention_weights: true
-        symbolic_overlay_weight: 0.12   # inflates σ where symbolic flags fire
+        export_attention_weights: false
+        symbolic_overlay_weight: 0.10
       flow:
-        type: "maf"              # ["maf","rq_coupling"]
-        num_transforms: 6
+        type: "maf"
+        num_transforms: 5
         context_dim: 256
         hidden_features: 256
         num_blocks_per_transform: 2
@@ -31,16 +30,16 @@ model:
         batch_norm: true
       calibration:
         enable: true
-        method: "corel"         # GNN-COREL binwise calibration after flow
+        method: "corel"
         corel:
           enabled: true
-          ckpt: null            # path resolved at runtime if provided
+          ckpt: null
           binwise: true
           graph:
             use_edge_features: true
             edge_types: ["distance","molecule","detector_region"]
           training:
-            epochs: 12
+            epochs: 10
             lr: 1.0e-3
             weight_decay: 1.0e-4
             batch_size: 64

--- a/configs/model/sigma_head/quantile.yaml
+++ b/configs/model/sigma_head/quantile.yaml
@@ -1,0 +1,29 @@
+# Quantile head: learns lower/upper quantiles; σ inferred from spread
+
+model:
+  decoders:
+    sigma_head:
+      kind: "quantile"
+      in_features: 256
+      hidden_features: 256
+      num_layers: 3
+      dropout: 0.05
+      activation: "relu"
+      init: "xavier_uniform"
+      quantile:
+        q_low: 0.159
+        q_high: 0.841
+        huber_delta: 0.0          # 0 = pure pinball; >0 = Huberized
+      output:
+        min_sigma: 1.0e-05
+        max_sigma: 0.7
+        clamp_strategy: "hard"
+      fusion:
+        enable_attention_fuse: false
+        symbolic_overlay_weight: 0.0
+      calibration:
+        enable: true
+        method: "temperature"
+        temperature:
+          init_t: 1.0
+          learn_t: true


### PR DESCRIPTION
## Summary
- add comprehensive sigma head configuration suite with defaults, gaussian, flow, evidential, quantile, ensemble, calibration, kaggle, leaderboard, and debug presets
- document usage and schema for sigma head configs

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch'; attempted to install but download was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_689cd3a95b40832aa6a3fdf0b2e4c68e