### PR TITLE
feat(configs): add model/src component configs for SpectraMindV50

### DIFF
--- a/configs/model/src/airs_gnn.yaml
+++ b/configs/model/src/airs_gnn.yaml
@@ -1,0 +1,9 @@
+# Hydra config for AIRS spectral GNN encoder
+_target_: spectramind.models.airs_gat.AIRSGAT
+input_dim: 256
+latent_dim: 256
+n_heads: 4
+n_layers: 3
+dropout: 0.1
+use_edges: true
+edge_dim: 4

--- a/configs/model/src/fgs1_mamba.yaml
+++ b/configs/model/src/fgs1_mamba.yaml
@@ -1,0 +1,8 @@
+# Hydra config for FGS1 Mamba encoder component
+_target_: spectramind.models.fgs1_mamba.FGS1Mamba
+input_dim: 4
+latent_dim: 256
+n_layers: 6
+bidirectional: true
+dropout: 0.1
+residual: true

--- a/configs/model/src/flow_uncertainty_head.yaml
+++ b/configs/model/src/flow_uncertainty_head.yaml
@@ -1,0 +1,4 @@
+# Hydra config for flow-based uncertainty head
+_target_: spectramind.models.flow_uncertainty_head.FlowUncertaintyHead
+out_bins: 283
+softplus: true

--- a/configs/model/src/fusion.yaml
+++ b/configs/model/src/fusion.yaml
@@ -1,0 +1,12 @@
+# Hydra config for fusion module
+_target_: spectramind.models.fusion.ConcatMLPFusion
+dim: 256
+dropout: 0.05
+norm: layernorm
+jit_safe: true
+export_taps: false
+export_attn: false
+export_gate: false
+d_fgs1: 256
+d_airs: 256
+strict_check: true

--- a/configs/model/src/multi_scale_decoder.yaml
+++ b/configs/model/src/multi_scale_decoder.yaml
@@ -1,0 +1,4 @@
+# Hydra config for multi-scale decoder
+_target_: spectramind.models.multi_scale_decoder.MultiScaleDecoder
+out_bins: 283
+multiscale: true

--- a/configs/model/src/symbolic_loss.yaml
+++ b/configs/model/src/symbolic_loss.yaml
@@ -1,0 +1,15 @@
+# Hydra config for symbolic loss
+_target_: spectramind.models.symbolic_loss.SymbolicLoss
+lambda_sm: 0.1
+lambda_nn: 0.05
+lambda_coh: 0.05
+lambda_seam: 0.01
+lambda_ratio: 0.02
+lambda_qm: 0.02
+enabled_rules:
+  - smoothness
+  - nonnegativity
+  - molecular_coherence
+  - seam_continuity
+  - ratio_constraints
+  - quantile_monotonicity


### PR DESCRIPTION
## Summary
- add Hydra config for FGS1 Mamba encoder
- add AIRS GNN, multi-scale decoder, flow uncertainty head, symbolic loss and fusion module configs

## Testing
- `PYTHONPATH=. pytest` *(fails: FGS1 latent D mismatch: expected 256, got 32)*

------
https://chatgpt.com/codex/tasks/task_e_689cda89bee8832a8fdb3f3014754056