### PR TITLE
feat(configs): add spectramind model/src component configs for V50

### DIFF
--- a/configs/model/src/spectramind/__init__.yaml
+++ b/configs/model/src/spectramind/__init__.yaml
@@ -1,0 +1,11 @@
+# Hydra default list for SpectraMind model components
+# These defaults compose the core model components for SpectraMind V50.
+
+defaults:
+  - fgs1_mamba
+  - airs_gnn
+  - multi_scale_decoder
+  - flow_uncertainty_head
+  - symbolic_loss
+  - fusion
+  - _self_

--- a/configs/model/src/spectramind/airs_gnn.yaml
+++ b/configs/model/src/spectramind/airs_gnn.yaml
@@ -1,0 +1,9 @@
+# Hydra config for AIRS spectral GNN encoder
+_target_: spectramind.models.airs_gat.AIRSGAT
+input_dim: 256
+latent_dim: 256
+n_heads: 4
+n_layers: 3
+dropout: 0.1
+use_edges: true
+edge_dim: 4

--- a/configs/model/src/spectramind/fgs1_mamba.yaml
+++ b/configs/model/src/spectramind/fgs1_mamba.yaml
@@ -1,0 +1,8 @@
+# Hydra config for FGS1 Mamba encoder component
+_target_: spectramind.models.fgs1_mamba.FGS1Mamba
+input_dim: 4
+latent_dim: 256
+n_layers: 6
+bidirectional: true
+dropout: 0.1
+residual: true

--- a/configs/model/src/spectramind/flow_uncertainty_head.yaml
+++ b/configs/model/src/spectramind/flow_uncertainty_head.yaml
@@ -1,0 +1,4 @@
+# Hydra config for flow-based uncertainty head
+_target_: spectramind.models.flow_uncertainty_head.FlowUncertaintyHead
+out_bins: 283
+softplus: true

--- a/configs/model/src/spectramind/fusion.yaml
+++ b/configs/model/src/spectramind/fusion.yaml
@@ -1,0 +1,12 @@
+# Hydra config for fusion module
+_target_: spectramind.models.fusion.ConcatMLPFusion
+dim: 256
+dropout: 0.05
+norm: layernorm
+jit_safe: true
+export_taps: false
+export_attn: false
+export_gate: false
+d_fgs1: 256
+d_airs: 256
+strict_check: true

--- a/configs/model/src/spectramind/multi_scale_decoder.yaml
+++ b/configs/model/src/spectramind/multi_scale_decoder.yaml
@@ -1,0 +1,4 @@
+# Hydra config for multi-scale decoder
+_target_: spectramind.models.multi_scale_decoder.MultiScaleDecoder
+out_bins: 283
+multiscale: true

--- a/configs/model/src/spectramind/symbolic_loss.yaml
+++ b/configs/model/src/spectramind/symbolic_loss.yaml
@@ -1,0 +1,15 @@
+# Hydra config for symbolic loss
+_target_: spectramind.models.symbolic_loss.SymbolicLoss
+lambda_sm: 0.1
+lambda_nn: 0.05
+lambda_coh: 0.05
+lambda_seam: 0.01
+lambda_ratio: 0.02
+lambda_qm: 0.02
+enabled_rules:
+  - smoothness
+  - nonnegativity
+  - molecular_coherence
+  - seam_continuity
+  - ratio_constraints
+  - quantile_monotonicity


### PR DESCRIPTION
## Summary
- add Hydra configs for SpectraMind encoder/decoder components
- provide default composition via spectramind `__init__.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch==2.3.1 torchvision==0.18.1 torchaudio==2.3.1 --extra-index-url https://download.pytorch.org/whl/cpu -q` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689ced654b6c832a84e1624c052fa456