### PR TITLE
feat(configs): add code-aware Hydra configs for spectramind/models (V50)

### DIFF
--- a/configs/model/src/spectramind/models/README.md
+++ b/configs/model/src/spectramind/models/README.md
@@ -1,0 +1,15 @@
+# SpectraMind V50 — `configs/model/src/spectramind/models`
+
+Hydra configs that bind model components to classes in `src/spectramind/models`.
+
+## Components
+- `fgs1_mamba.yaml` → `spectramind.models.fgs1_mamba.FGS1MambaEncoder`
+- `airs_gnn.yaml` → `spectramind.models.airs_gnn.AIRSGNNEncoder`
+- `multi_scale_decoder.yaml` → `spectramind.models.multi_scale_decoder.MultiScaleMuDecoder`
+- `flow_uncertainty_head.yaml` → `spectramind.models.flow_uncertainty_head.FlowUncertaintyHead`
+- `fusion.yaml` → `spectramind.models.fusion.FusionBlock`
+- `registry.yaml` → name→class mapping
+- `pipeline_active.yaml` → choose active components
+- `__init__.yaml` → group defaults
+
+See the SpectraMind V50 architecture docs for scientific & engineering rationale.

--- a/configs/model/src/spectramind/models/__init__.yaml
+++ b/configs/model/src/spectramind/models/__init__.yaml
@@ -1,0 +1,9 @@
+# Hydra defaults for the spectramind/models config group
+defaults:
+  - fgs1_mamba
+  - airs_gnn
+  - fusion
+  - multi_scale_decoder
+  - flow_uncertainty_head
+  - registry
+  - pipeline_active

--- a/configs/model/src/spectramind/models/airs_gnn.yaml
+++ b/configs/model/src/spectramind/models/airs_gnn.yaml
@@ -1,0 +1,17 @@
+# SpectraMind V50 — AIRS spectral GNN encoder (physics-informed GAT)
+# Binds to: src/spectramind/models/airs_gnn.py::AIRSGNNEncoder
+spectramind:
+  models:
+    airs_gnn:
+      class: "spectramind.models.airs_gnn.AIRSGNNEncoder"
+      params:
+        in_features: 256
+        gnn_type: "gat"
+        num_layers: 4
+        hidden_dim: 256
+        heads: 4
+        dropout: 0.10
+        edge_features: ["delta_lambda", "mol_tag_i", "mol_tag_j", "seam_flag"]
+        use_edge_attr: true
+        export_attention_weights: true
+        torchscript_safe: true

--- a/configs/model/src/spectramind/models/fgs1_mamba.yaml
+++ b/configs/model/src/spectramind/models/fgs1_mamba.yaml
@@ -1,0 +1,20 @@
+# SpectraMind V50 — FGS1 Mamba SSM encoder (temporal, long-sequence)
+# Binds to: src/spectramind/models/fgs1_mamba.py::FGS1MambaEncoder
+spectramind:
+  models:
+    fgs1_mamba:
+      class: "spectramind.models.fgs1_mamba.FGS1MambaEncoder"
+      params:
+        in_features: 6
+        d_model: 256
+        d_state: 64
+        d_conv: 4
+        expand: 2
+        n_layers: 8
+        bidirectional: true
+        dropout: 0.10
+        layer_norm: "rms"
+        proj_out: 256
+        export_step_latents: false
+        amp: true
+        torchscript_safe: true

--- a/configs/model/src/spectramind/models/flow_uncertainty_head.yaml
+++ b/configs/model/src/spectramind/models/flow_uncertainty_head.yaml
@@ -1,0 +1,16 @@
+# SpectraMind V50 — σ head (flow / quantile / mlp), Softplus with floor
+# Binds to: src/spectramind/models/flow_uncertainty_head.py::FlowUncertaintyHead
+spectramind:
+  models:
+    flow_uncertainty_head:
+      class: "spectramind.models.flow_uncertainty_head.FlowUncertaintyHead"
+      params:
+        type: "flow"
+        hidden_dim: 256
+        dropout: 0.05
+        activation: "gelu"
+        min_sigma: 1.0e-4
+        softplus: true
+        predict_quantiles: false
+        quantile_monotonicity_loss: true
+        torchscript_safe: true

--- a/configs/model/src/spectramind/models/fusion.yaml
+++ b/configs/model/src/spectramind/models/fusion.yaml
@@ -1,0 +1,12 @@
+# SpectraMind V50 — Latent fusion between FGS1 & AIRS encoders
+# Binds to: src/spectramind/models/fusion.py::FusionBlock
+spectramind:
+  models:
+    fusion:
+      class: "spectramind.models.fusion.FusionBlock"
+      params:
+        type: "concat_mlp"
+        hidden_dim: 256
+        dropout: 0.05
+        gate_init_bias: 0.0
+        symbolic_aware: true

--- a/configs/model/src/spectramind/models/multi_scale_decoder.yaml
+++ b/configs/model/src/spectramind/models/multi_scale_decoder.yaml
@@ -1,0 +1,14 @@
+# SpectraMind V50 — Multi-scale μ decoder (coarse→mid→fine with skips)
+# Binds to: src/spectramind/models/multi_scale_decoder.py::MultiScaleMuDecoder
+spectramind:
+  models:
+    multi_scale_decoder:
+      class: "spectramind.models.multi_scale_decoder.MultiScaleMuDecoder"
+      params:
+        base_dim: 256
+        scales: ["coarse","mid","fine"]
+        skip_connections: true
+        activation: "gelu"
+        dropout: 0.05
+        output_bins: 283
+        symbolic_aware: true

--- a/configs/model/src/spectramind/models/pipeline_active.yaml
+++ b/configs/model/src/spectramind/models/pipeline_active.yaml
@@ -1,0 +1,9 @@
+# SpectraMind V50 — Active model selection for the pipeline
+spectramind:
+  models:
+    active:
+      encoder_fgs1: "fgs1_mamba"
+      encoder_airs: "airs_gnn"
+      fusion: "fusion"
+      mu_decoder: "multi_scale_decoder"
+      sigma_head: "flow_uncertainty_head"

--- a/configs/model/src/spectramind/models/registry.yaml
+++ b/configs/model/src/spectramind/models/registry.yaml
@@ -1,0 +1,9 @@
+# SpectraMind V50 — Model registry to enforce import paths & friendly names
+spectramind:
+  models:
+    registry:
+      FGS1MambaEncoder: "spectramind.models.fgs1_mamba.FGS1MambaEncoder"
+      AIRSGNNEncoder: "spectramind.models.airs_gnn.AIRSGNNEncoder"
+      MultiScaleMuDecoder: "spectramind.models.multi_scale_decoder.MultiScaleMuDecoder"
+      FlowUncertaintyHead: "spectramind.models.flow_uncertainty_head.FlowUncertaintyHead"
+      FusionBlock: "spectramind.models.fusion.FusionBlock"


### PR DESCRIPTION
## Summary
- add Hydra config group for `spectramind.models` components
- register encoders, decoder, fusion, and uncertainty head, with active pipeline defaults

## Testing
- `PYTHONPATH=. pytest -q` *(fails: FGS1 latent D mismatch: expected 256, got 32)*

------
https://chatgpt.com/codex/tasks/task_e_689cf18fb718832ab8e463f60abc2bd4