### PR TITLE
chore: add VSCode workspace config for SpectraMind V50

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,11 @@ venv/
 # IDE
 .vscode/*
 !.vscode/settings.json
+!.vscode/extensions.json
+!.vscode/launch.json
+!.vscode/tasks.json
+!.vscode/snippets/
+!.vscode/snippets/**
 .idea/
 
 # Data / Artifacts

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,14 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-toolsai.jupyter",
+    "ms-python.black-formatter",
+    "ms-azuretools.vscode-docker",
+    "redhat.vscode-yaml",
+    "ms-toolsai.data-science",
+    "njpwerner.autodocstring",
+    "ms-vsliveshare.vsliveshare",
+    "mhutchie.git-graph",
+    "eamodio.gitlens"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,37 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Train SpectraMind V50",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/train_v50.py",
+      "console": "integratedTerminal",
+      "args": ["--config", "configs/config_v50.yaml"]
+    },
+    {
+      "name": "Predict with V50",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/predict_v50.py",
+      "console": "integratedTerminal",
+      "args": ["--input", "data/calibrated", "--output", "submissions/latest.csv"]
+    },
+    {
+      "name": "Run CLI Diagnostics",
+      "type": "python",
+      "request": "launch",
+      "program": "${workspaceFolder}/cli_diagnose.py",
+      "console": "integratedTerminal",
+      "args": ["dashboard", "--open-html"]
+    },
+    {
+      "name": "Run Unit Tests",
+      "type": "python",
+      "request": "launch",
+      "module": "pytest",
+      "args": ["-v", "tests/"],
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,33 @@
 {
-  "python.defaultInterpreterPath": "python",
-  "python.testing.pytestEnabled": true,
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+  "python.analysis.typeCheckingMode": "basic",
+  "python.linting.enabled": true,
+  "python.linting.pylintEnabled": true,
   "python.formatting.provider": "black",
   "editor.formatOnSave": true,
-  "editor.rulers": [100],
-  "files.eol": "\n",
-  "python.analysis.typeCheckingMode": "basic"
+  "editor.codeActionsOnSave": {
+    "source.organizeImports": true
+  },
+  "files.exclude": {
+    "**/__pycache__": true,
+    "**/.mypy_cache": true,
+    "**/.pytest_cache": true
+  },
+  "jupyter.askForKernelRestart": false,
+  "jupyter.notebookFileRoot": "${workspaceFolder}",
+  "yaml.schemas": {
+    "https://json.schemastore.org/github-workflow.json": "/*.github/workflows/*",
+    "https://json.schemastore.org/github-action.json": "/.github/actions/*"
+  },
+  "notebook.cellToolbarVisibility": "hover",
+  "notebook.output.textLineLimit": 1000,
+  "python.testing.pytestEnabled": true,
+  "python.testing.pytestArgs": [
+    "tests"
+  ],
+  "python.envFile": "${workspaceFolder}/.env",
+  "terminal.integrated.defaultProfile.linux": "bash",
+  "editor.rulers": [88],
+  "files.trimTrailingWhitespace": true,
+  "files.insertFinalNewline": true
 }

--- a/.vscode/snippets/spectramind.code-snippets
+++ b/.vscode/snippets/spectramind.code-snippets
@@ -1,0 +1,29 @@
+{
+  "SpectraMind Config Loader": {
+    "prefix": "sm-config",
+    "body": [
+      "import hydra",
+      "from omegaconf import DictConfig",
+      "",
+      "@hydra.main(config_path=\"configs\", config_name=\"$1\")",
+      "def main(cfg: DictConfig):",
+      "    print(cfg)",
+      "",
+      "if __name__ == \"__main__\":",
+      "    main()"
+    ],
+    "description": "Hydra config loader pattern for SpectraMind V50"
+  },
+  "SpectraMind Logger": {
+    "prefix": "sm-logger",
+    "body": [
+      "import logging",
+      "logging.basicConfig(",
+      "    format='%(asctime)s [%(levelname)s] %(message)s',",
+      "    level=logging.INFO",
+      ")",
+      "logger = logging.getLogger(__name__)"
+    ],
+    "description": "Standardized logger setup for SpectraMind V50"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Install Environment",
+      "type": "shell",
+      "command": "poetry install --no-root",
+      "group": "build"
+    },
+    {
+      "label": "Run Selftest",
+      "type": "shell",
+      "command": "python selftest.py --mode fast",
+      "group": "test"
+    },
+    {
+      "label": "Run Full Diagnostics",
+      "type": "shell",
+      "command": "python cli_diagnose.py dashboard --open-html",
+      "group": "test"
+    },
+    {
+      "label": "Submit Kaggle",
+      "type": "shell",
+      "command": "python cli_submit.py --fast-kaggle",
+      "group": "build"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add VSCode settings for linting, formatting, testing, and workspace defaults
- add recommended extensions, launch configurations, tasks, and common code snippets
- update gitignore to allow committing VSCode configuration

## Testing
- `pre-commit run --files .vscode/settings.json .vscode/extensions.json .vscode/launch.json .vscode/tasks.json .vscode/snippets/spectramind.code-snippets .gitignore` *(command not found)*
- `pytest` *(missing torch)*

------
https://chatgpt.com/codex/tasks/task_e_689d6ea43258832a8451c0a612e1c753