### PR TITLE
feat: add comprehensive calibration config pack

### DIFF
--- a/configs/calibration/README.md
+++ b/configs/calibration/README.md
@@ -1,0 +1,51 @@
+SpectraMind V50 — Calibration Configs
+
+This directory contains Hydra-safe configuration for the calibration kill chain used by SpectraMind V50
+before feature extraction and modeling. It encodes reproducible, documented, and CI-validated knobs
+for each step:
+•Base config (base.yaml) — canonical structure and defaults. All environments compose from this.
+•Environment overlays — local.yaml, kaggle.yaml, cluster.yaml.
+•Policies (policies.yaml) — IO rules, caching, variance propagation, logging detail, safety guards.
+•Steps (steps/*.yaml) — ADC, nonlinearity, dark/flat/bias corrections, trace extraction, photometry,
+normalization, temporal alignment, jitter correction, variance propagation.
+•Uncertainty calibration — temperature scaling, COREL (graph conformal), conformal fallback.
+•Diagnostics (steps/diagnostics.yaml) — CSV/PNG/HTML outputs, quick plots, timing summaries.
+•Schema (schema/calibration_config.schema.json) — JSON Schema used in CI to validate structure.
+
+Hydra Composition Examples
+
+Local quick dev:
+
+python -m spectramind calibrate \
+  +calib@_global=configs/calibration/base.yaml \
+  +calib_env=local \
+  +calib_steps=default
+
+Kaggle runtime guardrails:
+
+python -m spectramind calibrate \
+  +calib@_global=configs/calibration/base.yaml \
+  +calib_env=kaggle \
+  steps.diagnostics.enable=true \
+  policies.runtime.max_hours=9
+
+Cluster (multi-GPU / fast IO):
+
+python -m spectramind calibrate \
+  +calib@_global=configs/calibration/base.yaml \
+  +calib_env=cluster \
+  io.prefetch_workers=8 io.loader_workers=16
+
+File Map (short)
+•base.yaml: master tree (paths, io, policies, steps, logging).
+•policies.yaml: centralizes safety, caching, variance rules, overwrite modes.
+•local.yaml, kaggle.yaml, cluster.yaml: environment diffs only.
+•steps/*.yaml: per-step parameters; imported by base.yaml.
+•schema/calibration_config.schema.json: CI/type guard for base.yaml render.
+
+Principles
+•Never clip negatives in calibrated frames; carry full variance.
+•One source of truth for seeds/workers/logging levels.
+•Hydra-safe: no structural changes in env overlays; only values differ.
+•Fast-fail diagnostics: misconfiguration detected early via schema + selftest.
+

--- a/configs/calibration/base.yaml
+++ b/configs/calibration/base.yaml
@@ -1,5 +1,104 @@
-calibration:
-  enabled: true
-  method: "temperature_scaling"     # "temperature_scaling" | "corel"
-  temperature: 1.0
-  save_dir: "${paths.root}/artifacts/calibration"
+# --------------------------------------------------------------
+# SpectraMind V50 — Calibration Base (canonical structure)
+#
+# This file defines the full tree. Environment overlays may change values
+# but MUST NOT change structure (Hydra-safe).
+# --------------------------------------------------------------
+
+calib:
+  version: "v50"
+  seed: 1337
+
+  # ---- Paths (override in env overlays) ----
+  paths:
+    root: "${oc.env:SM_ROOT,${hydra:runtime.cwd}}"
+    raw:  "${calib.paths.root}/data/raw"
+    work: "${calib.paths.root}/data/work"
+    out:  "${calib.paths.root}/artifacts/calibrated"
+    logs: "${calib.paths.root}/artifacts/logs"
+    cache: "${calib.paths.root}/.cache/calib"
+
+  # ---- IO / Loader ----
+  io:
+    loader_workers: 4
+    prefetch_workers: 2
+    pin_memory: true
+    dtype: "float32"
+    chunks:
+      enable: true
+      size_time: 2048         # chunk length along time
+      overlap: 64
+    cache:
+      enable: true
+      policy: "auto"          # [auto|force|off]
+      max_gb: 12
+
+  # ---- Policies (import defaults; allow overlay) ----
+  policies:
+    target: "include"
+    file: "configs/calibration/policies.yaml"
+
+  # ---- Steps: include per-step configs ----
+  steps:
+    adc:
+      file: "configs/calibration/steps/adc.yaml"
+    nonlinearity:
+      file: "configs/calibration/steps/nonlinearity.yaml"
+    dark:
+      file: "configs/calibration/steps/dark.yaml"
+    flat:
+      file: "configs/calibration/steps/flat.yaml"
+    bias:
+      file: "configs/calibration/steps/bias.yaml"
+    trace_extraction:
+      file: "configs/calibration/steps/trace_extraction.yaml"
+    photometry:
+      file: "configs/calibration/steps/photometry.yaml"
+    normalization:
+      file: "configs/calibration/steps/normalization.yaml"
+    alignment:
+      file: "configs/calibration/steps/alignment.yaml"
+    jitter:
+      file: "configs/calibration/steps/jitter.yaml"
+    variance:
+      file: "configs/calibration/steps/variance.yaml"
+
+    # Uncertainty calibration stack
+    temperature_scaling:
+      _file_: "configs/calibration/steps/temperature_scaling.yaml"
+    corel:
+      _file_: "configs/calibration/steps/corel.yaml"
+    conformal:
+      _file_: "configs/calibration/steps/conformal.yaml"
+
+    diagnostics:
+      _file_: "configs/calibration/steps/diagnostics.yaml"
+
+  # ---- Logging ----
+  logging:
+    level: "INFO"             # [DEBUG|INFO|WARNING|ERROR]
+    console: true
+    file:
+      enable: true
+      path: "${calib.paths.logs}/calibration.log"
+      rotate_mb: 50
+      keep: 5
+    jsonl:
+      enable: true
+      path: "${calib.paths.logs}/calibration_events.jsonl"
+
+  # ---- Runtime Guards ----
+  runtime:
+    max_hours: 9               # Kaggle guardrail; can be >9 elsewhere
+    fail_fast: true
+    dry_run: false
+    deterministic: true
+
+  # ---- Reproducibility ----
+  repro:
+    capture:
+      git: true
+      env: true
+      pip_freeze: true
+      hydra_config_dump: true
+    outputs_manifest: "${calib.paths.out}/calibration_manifest.json"

--- a/configs/calibration/cluster.yaml
+++ b/configs/calibration/cluster.yaml
@@ -1,0 +1,14 @@
+# Cluster/HPC overlays (parallel IO; large caches)
+
+calib:
+  io:
+    loader_workers: 16
+    prefetch_workers: 8
+    cache:
+      max_gb: 64
+  logging:
+    level: "INFO"
+  runtime:
+    max_hours: 48
+    fail_fast: true
+

--- a/configs/calibration/corel.yaml
+++ b/configs/calibration/corel.yaml
@@ -1,6 +1,0 @@
-calibration:
-  enabled: true
-  method: "corel"
-  target_coverage: 0.90
-  graph_backend: "gat"              # gat | rgcn
-  save_dir: "${paths.root}/artifacts/calibration/corel"

--- a/configs/calibration/kaggle.yaml
+++ b/configs/calibration/kaggle.yaml
@@ -1,0 +1,21 @@
+# Kaggle runner overlays (tight resources and wall-time)
+
+calib:
+  paths:
+    root: "${hydra:runtime.cwd}"
+  io:
+    loader_workers: 2
+    prefetch_workers: 1
+    cache:
+      max_gb: 6
+  logging:
+    level: "INFO"
+    file:
+      enable: true
+  runtime:
+    max_hours: 9
+    fail_fast: true
+  repro:
+    capture:
+      pip_freeze: false   # keep light on Kaggle if storage constrained
+

--- a/configs/calibration/local.yaml
+++ b/configs/calibration/local.yaml
@@ -1,0 +1,13 @@
+# Local workstation overrides (fast iteration)
+
+calib:
+  paths:
+    root: "${oc.env:SM_ROOT,${hydra:runtime.cwd}}"
+  io:
+    loader_workers: 8
+    prefetch_workers: 4
+  logging:
+    level: "DEBUG"
+  runtime:
+    max_hours: 24
+

--- a/configs/calibration/policies.yaml
+++ b/configs/calibration/policies.yaml
@@ -1,0 +1,25 @@
+# Centralized IO / caching / safety policies for calibration.
+
+policies:
+  overwrite:
+    calibrated_frames: "auto"     # [always|never|auto]
+    intermediate: "auto"
+  variance:
+    propagate: true               # always carry variance channels forward
+    dtype: "float32"
+    epsilon: 1.0e-8
+  bounds:
+    clip_negatives: false         # scientific policy: never clip; analyze downstream
+    saturate_high_sigma: false
+  caching:
+    read_through: true
+    write_back: true
+  integrity:
+    checksum:
+      enable: true
+      algo: "blake2b"
+  logging:
+    step_timing: true
+    memory: true
+    per_file_summary: true
+

--- a/configs/calibration/schema/calibration_config.schema.json
+++ b/configs/calibration/schema/calibration_config.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SpectraMind V50 Calibration Config (Rendered)",
+  "type": "object",
+  "required": ["calib"],
+  "properties": {
+    "calib": {
+      "type": "object",
+      "required": ["version","paths","io","policies","steps","logging","runtime","repro"],
+      "properties": {
+        "version": { "type": "string" },
+        "paths": {
+          "type": "object",
+          "required": ["root","raw","work","out","logs","cache"],
+          "properties": {
+            "root": { "type": "string" },
+            "raw":  { "type": "string" },
+            "work": { "type": "string" },
+            "out":  { "type": "string" },
+            "logs": { "type": "string" },
+            "cache":{ "type": "string" }
+          }
+        },
+        "io": {
+          "type": "object",
+          "required": ["loader_workers","prefetch_workers","pin_memory","dtype","cache"],
+          "properties": {
+            "loader_workers": { "type": "integer", "minimum": 0 },
+            "prefetch_workers": { "type": "integer", "minimum": 0 },
+            "pin_memory": { "type": "boolean" },
+            "dtype": { "type": "string", "enum": ["float16","float32","float64"] },
+            "chunks": {
+              "type": "object",
+              "properties": {
+                "enable": { "type": "boolean" },
+                "size_time": { "type": "integer", "minimum": 1 },
+                "overlap": { "type": "integer", "minimum": 0 }
+              }
+            },
+            "cache": {
+              "type": "object",
+              "required": ["enable","policy","max_gb"],
+              "properties": {
+                "enable": { "type": "boolean" },
+                "policy": { "type": "string", "enum": ["auto","force","off"] },
+                "max_gb": { "type": "number", "minimum": 0 }
+              }
+            }
+          }
+        },
+        "policies": { "type": "object" },
+        "steps":   { "type": "object" },
+        "logging": {
+          "type": "object",
+          "required": ["level","console","file","jsonl"],
+          "properties": {
+            "level": { "type": "string", "enum": ["DEBUG","INFO","WARNING","ERROR"] },
+            "console": { "type": "boolean" },
+            "file": {
+              "type": "object",
+              "required": ["enable","path","rotate_mb","keep"],
+              "properties": {
+                "enable": { "type": "boolean" },
+                "path": { "type": "string" },
+                "rotate_mb": { "type": "number", "minimum": 1 },
+                "keep": { "type": "integer", "minimum": 1 }
+              }
+            },
+            "jsonl": {
+              "type": "object",
+              "required": ["enable","path"],
+              "properties": {
+                "enable": { "type": "boolean" },
+                "path": { "type": "string" }
+              }
+            }
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "required": ["max_hours","fail_fast","dry_run","deterministic"],
+          "properties": {
+            "max_hours": { "type": "number", "minimum": 0 },
+            "fail_fast": { "type": "boolean" },
+            "dry_run": { "type": "boolean" },
+            "deterministic": { "type": "boolean" }
+          }
+        },
+        "repro": {
+          "type": "object",
+          "required": ["capture","outputs_manifest"],
+          "properties": {
+            "capture": {
+              "type": "object",
+              "required": ["git","env","pip_freeze","hydra_config_dump"],
+              "properties": {
+                "git": { "type": "boolean" },
+                "env": { "type": "boolean" },
+                "pip_freeze": { "type": "boolean" },
+                "hydra_config_dump": { "type": "boolean" }
+              }
+            },
+            "outputs_manifest": { "type": "string" }
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/configs/calibration/steps/adc.yaml
+++ b/configs/calibration/steps/adc.yaml
@@ -1,0 +1,15 @@
+# Analog-to-Digital Conversion correction
+
+steps:
+  adc:
+    enable: true
+    method: "gain_map"               # [gain_map|polynomial|none]
+    gain_map_path: "${calib.paths.root}/refs/calibration/adc_gain_map.fits"
+    bias_level_subtract: true
+    bias_level_method: "per-row"     # [global|per-row|per-col]
+    saturation_level_adu: 65535
+    outlier_mask:
+      enable: true
+      sigma: 6.0
+      dilate: 1
+

--- a/configs/calibration/steps/alignment.yaml
+++ b/configs/calibration/steps/alignment.yaml
@@ -1,0 +1,17 @@
+# Temporal alignment (FGS1-informed) and phase normalization
+
+steps:
+  alignment:
+    enable: true
+    reference: "FGS1_transit_shape"  # [FGS1_transit_shape|midpoint|header_time]
+    crosscorr:
+      enable: true
+      max_lag_frames: 64
+      window_frames: 512
+    barycentric:
+      apply: false                   # enable if BJD_TDB correction data present
+    resample:
+      enable: true
+      method: "linear"               # [linear|cubic|lanczos]
+      target_grid: "common"
+

--- a/configs/calibration/steps/bias.yaml
+++ b/configs/calibration/steps/bias.yaml
@@ -1,0 +1,12 @@
+# Residual bias pattern correction
+
+steps:
+  bias:
+    enable: true
+    master_bias_path: "${calib.paths.root}/refs/calibration/master_bias.fits"
+    pattern_remove:
+      enable: true
+      method: "rowcol"           # remove row/col fixed pattern
+      row_strength: 0.8
+      col_strength: 0.8
+

--- a/configs/calibration/steps/conformal.yaml
+++ b/configs/calibration/steps/conformal.yaml
@@ -1,0 +1,11 @@
+# Non-parametric conformal fallback if COREL disabled/unavailable
+
+steps:
+  conformal:
+    enable: false
+    method: "inductive"               # [inductive|split]
+    alpha: 0.10
+    calibration_strategy: "per-bin"   # [global|per-bin]
+    smoothing: "moving_avg"
+    window_bins: 5
+

--- a/configs/calibration/steps/corel.yaml
+++ b/configs/calibration/steps/corel.yaml
@@ -1,0 +1,28 @@
+# COREL-style conformal calibration via spectral GNN (binwise coverage)
+
+steps:
+  corel:
+    enable: true
+    graph:
+      build: "wavelength_proximity"   # edges link neighboring bins
+      k_neighbors: 4
+      edge_features:
+        - "delta_wavelength"
+        - "molecule_region"          # optional one-hot; if available
+    gnn:
+      backend: "GAT"                 # [GAT|RGCN|NNConv]
+      layers: 3
+      hidden_dim: 64
+      heads: 4
+      dropout: 0.1
+    coverage:
+      target: 0.90
+      metric: "quantile"
+      per_region_summary: true
+    training:
+      epochs: 50
+      batch_size: 8
+      lr: 2.0e-3
+      weight_decay: 1.0e-4
+      early_stop_patience: 8
+

--- a/configs/calibration/steps/dark.yaml
+++ b/configs/calibration/steps/dark.yaml
@@ -1,0 +1,13 @@
+# Dark current subtraction
+
+steps:
+  dark:
+    enable: true
+    master_dark_path: "${calib.paths.root}/refs/calibration/master_dark.fits"
+    scale:
+      enable: true
+      method: "exptime"            # scale dark by exposure time
+    hot_pixel_mask:
+      enable: true
+      threshold_e_per_s: 0.5
+

--- a/configs/calibration/steps/diagnostics.yaml
+++ b/configs/calibration/steps/diagnostics.yaml
@@ -1,0 +1,28 @@
+# Calibration diagnostics: CSV/PNG/HTML outputs for quick verification
+
+steps:
+  diagnostics:
+    enable: true
+    outputs:
+      dir: "${calib.paths.out}/diagnostics"
+      csv: true
+      png: true
+      html: true
+    plots:
+      time_series:
+        enable: true
+        sample_every: 10
+      fft_power:
+        enable: true
+        window: 1024
+        overlap: 256
+      zscore_hist:
+        enable: true
+        bins: 50
+      coverage_heatmap:
+        enable: true
+        source: "corel"               # [corel|conformal|none]
+    logging:
+      timing_table: true
+      memory_peaks: true
+

--- a/configs/calibration/steps/flat.yaml
+++ b/configs/calibration/steps/flat.yaml
@@ -1,0 +1,10 @@
+# Flat field correction
+
+steps:
+  flat:
+    enable: true
+    master_flat_path: "${calib.paths.root}/refs/calibration/master_flat.fits"
+    normalize: true
+    illumination_correction: true
+    fringe_correction: false
+

--- a/configs/calibration/steps/jitter.yaml
+++ b/configs/calibration/steps/jitter.yaml
@@ -1,0 +1,16 @@
+# Pointing jitter correction (decorrelation vs centroid/time)
+
+steps:
+  jitter:
+    enable: true
+    regressors:
+      - "centroid_x"
+      - "centroid_y"
+      - "time"
+    model: "ridge"                  # [ols|ridge|lasso]
+    alpha: 1.0
+    interaction_terms: true
+    rolling_window:
+      enable: true
+      frames: 256
+

--- a/configs/calibration/steps/nonlinearity.yaml
+++ b/configs/calibration/steps/nonlinearity.yaml
@@ -1,0 +1,10 @@
+# Sensor nonlinearity correction
+
+steps:
+  nonlinearity:
+    enable: true
+    model: "poly"                  # [poly|lookup|none]
+    poly_order: 3
+    coeff_path: "${calib.paths.root}/refs/calibration/nonlinearity_coeffs.fits"
+    clip_after: false
+

--- a/configs/calibration/steps/normalization.yaml
+++ b/configs/calibration/steps/normalization.yaml
@@ -1,0 +1,16 @@
+# Flux normalization (out-of-transit / robust detrending)
+
+steps:
+  normalization:
+    enable: true
+    method: "oot_robust"            # [oot_robust|percentile|poly]
+    oot_window:
+      pre_event_frac: 0.3
+      post_event_frac: 0.3
+    robust:
+      iqr_sigma: 2.5
+      max_iter: 3
+    poly:
+      order: 2
+      fit_on_oot: true
+

--- a/configs/calibration/steps/photometry.yaml
+++ b/configs/calibration/steps/photometry.yaml
@@ -1,0 +1,19 @@
+# Aperture photometry (FGS1) and spectral bin photometry (AIRS)
+
+steps:
+  photometry:
+    enable: true
+    mode: "aperture"                # [aperture|spectral_bins]
+    aperture:
+      radius_px: 4.0
+      annulus_inner_px: 6.0
+      annulus_outer_px: 10.0
+    centroid:
+      enable: true
+      method: "gaussian"
+    spectral_bins:
+      bin_edges_path: "${calib.paths.root}/refs/spectral/bin_edges_283.npy"
+      weighting: "variance"         # [uniform|variance]
+    normalization:
+      enable: false                 # handled in normalization step
+

--- a/configs/calibration/steps/temperature_scaling.yaml
+++ b/configs/calibration/steps/temperature_scaling.yaml
@@ -1,0 +1,16 @@
+# Temperature scaling for predicted σ calibration
+
+steps:
+  temperature_scaling:
+    enable: true
+    mode: "per-bin"                # [global|per-bin]
+    init_temp: 1.0
+    bounds: [0.2, 5.0]
+    optimizer:
+      type: "lbfgs"
+      max_iter: 200
+      tol: 1.0e-6
+    val_split:
+      method: "time_fold"
+      folds: 5
+

--- a/configs/calibration/steps/trace_extraction.yaml
+++ b/configs/calibration/steps/trace_extraction.yaml
@@ -1,0 +1,17 @@
+# Spectral trace extraction (AIRS) and aperture definition (FGS1/photometry)
+
+steps:
+  trace_extraction:
+    enable: true
+    instrument: "AIRS"              # [AIRS|FGS1]
+    method: "optimal"               # [sum|optimal]
+    profile_sigma_pix: 2.0
+    trace_poly:
+      enable: true
+      order: 3
+      fit_window_px: 15
+    background:
+      method: "local_median"
+      windows_px: 20
+      robust: true
+

--- a/configs/calibration/steps/variance.yaml
+++ b/configs/calibration/steps/variance.yaml
@@ -1,0 +1,11 @@
+# Variance propagation and z-score sanity checks
+
+steps:
+  variance:
+    enable: true
+    propagate_all: true
+    zscore_check:
+      enable: true
+      bins: 50
+      max_outlier_frac: 0.02
+

--- a/configs/calibration/temperature_scaling.yaml
+++ b/configs/calibration/temperature_scaling.yaml
@@ -1,8 +1,0 @@
-calibration:
-  enabled: true
-  method: "temperature_scaling"
-  temperature: 1.0
-  search:
-    enabled: true
-    grid: [0.5, 0.75, 1.0, 1.25, 1.5]
-    metric: "nll"                   # optimize negative log-likelihood


### PR DESCRIPTION
## Summary
- add full SpectraMind V50 calibration configuration pack with base config and environment overlays
- define per-step calibration settings and diagnostics
- include JSON schema for CI validation

## Testing
- `pre-commit run --files $(git ls-files configs/calibration)`


------
https://chatgpt.com/codex/tasks/task_e_689d75049878832abe1c71d16184b877