### PR TITLE
feat(configs): add symbolic molecules suite

### DIFF
--- a/configs/symbolic/molecules/README.md
+++ b/configs/symbolic/molecules/README.md
@@ -1,0 +1,21 @@
+# configs/symbolic/molecules
+
+Symbolic, human-friendly chemical knowledge for pipelines:
+- `periodic_table.yaml` — minimal extendable element facts
+- `bonds.yaml` — bond orders & canonical ranges
+- `functional_groups.yaml` — compact group patterns
+- `amino_acids.yaml` — biochemical reference (subset as starter)
+- `spectroscopy.yaml` — exoplanet-relevant molecules + bands/lines
+- `symbolic_map.yaml` — how symbols resolve to runtime assets
+- `_schemas/molecule.schema.json` — JSON Schema used by validation
+
+## Validate locally
+Use any YAML->JSON + JSON Schema validator (e.g., `yajsv`, `ajv`). Example:
+```bash
+yq -o=json '.molecules[]' spectroscopy.yaml | ajv -s _schemas/molecule.schema.json -d /dev/stdin
+```
+
+Conventions
+  • IDs: kebab_or_snake, immutable and code-facing.
+  • Fields are deliberately conservative; add domain fields as needed.
+  • Keep provenance in spectral.references.

--- a/configs/symbolic/molecules/_schemas/molecule.schema.json
+++ b/configs/symbolic/molecules/_schemas/molecule.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MoleculeDefinition",
+  "type": "object",
+  "required": ["id", "name", "formula"],
+  "properties": {
+    "id":      { "type": "string", "pattern": "^[a-z0-9_\\-]+$" },
+    "name":    { "type": "string" },
+    "formula": { "type": "string" },
+    "aliases": { "type": "array", "items": { "type": "string" } },
+    "properties": {
+      "type": "object",
+      "properties": {
+        "molar_mass_g_mol": { "type": "number" },
+        "state_ambient":    { "type": "string", "enum": ["solid","liquid","gas","plasma","unknown"] },
+        "notes":            { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "spectral": {
+      "type": "object",
+      "properties": {
+        "bands_um":      { "type": "array", "items": { "type": "number" } },
+        "lines_nm":      { "type": "array", "items": { "type": "number" } },
+        "windows_um":    { "type": "array", "items": { "type": "number" } },
+        "references":    { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "tags":    { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}

--- a/configs/symbolic/molecules/amino_acids.yaml
+++ b/configs/symbolic/molecules/amino_acids.yaml
@@ -1,0 +1,41 @@
+amino_acids:
+  - code: G
+    name: Glycine
+    formula: C2H5NO2
+    mass_g_mol: 75.07
+  - code: A
+    name: Alanine
+    formula: C3H7NO2
+    mass_g_mol: 89.09
+  - code: S
+    name: Serine
+    formula: C3H7NO3
+    mass_g_mol: 105.09
+  - code: T
+    name: Threonine
+    formula: C4H9NO3
+    mass_g_mol: 119.12
+  - code: C
+    name: Cysteine
+    formula: C3H7NO2S
+    mass_g_mol: 121.16
+  - code: M
+    name: Methionine
+    formula: C5H11NO2S
+    mass_g_mol: 149.21
+  - code: P
+    name: Proline
+    formula: C5H9NO2
+    mass_g_mol: 115.13
+  - code: F
+    name: Phenylalanine
+    formula: C9H11NO2
+    mass_g_mol: 165.19
+  - code: W
+    name: Tryptophan
+    formula: C11H12N2O2
+    mass_g_mol: 204.23
+  - code: Y
+    name: Tyrosine
+    formula: C9H11NO3
+    mass_g_mol: 181.19

--- a/configs/symbolic/molecules/bonds.yaml
+++ b/configs/symbolic/molecules/bonds.yaml
@@ -1,0 +1,13 @@
+bond_types:
+  - id: single
+    order: 1
+    typical_length_angstrom: [1.09, 1.54] # H-H .. C-C ranges
+  - id: double
+    order: 2
+    typical_length_angstrom: [1.20, 1.34]
+  - id: triple
+    order: 3
+    typical_length_angstrom: [1.09, 1.20]
+aromatic:
+  planar: true
+  resonance: true

--- a/configs/symbolic/molecules/functional_groups.yaml
+++ b/configs/symbolic/molecules/functional_groups.yaml
@@ -1,0 +1,13 @@
+groups:
+  - id: hydroxyl
+    pattern: "R-OH"
+    properties: { polarity: high, hydrogen_bond_donor: true }
+  - id: carbonyl
+    pattern: "R-(C=O)-R'"
+    properties: { polarity: high, hydrogen_bond_acceptor: true }
+  - id: carboxyl
+    pattern: "R-COOH"
+    properties: { acidity: weak_acid }
+  - id: amine
+    pattern: "R-NH2"
+    properties: { basicity: weak_base }

--- a/configs/symbolic/molecules/periodic_table.yaml
+++ b/configs/symbolic/molecules/periodic_table.yaml
@@ -1,0 +1,38 @@
+# Minimal, extendable subset for symbolic mapping in pipelines.
+elements:
+  - Z: 1
+    symbol: H
+    name: Hydrogen
+    group: 1
+    period: 1
+    molar_mass_g_mol: 1.00784
+  - Z: 6
+    symbol: C
+    name: Carbon
+    group: 14
+    period: 2
+    molar_mass_g_mol: 12.011
+  - Z: 7
+    symbol: N
+    name: Nitrogen
+    group: 15
+    period: 2
+    molar_mass_g_mol: 14.007
+  - Z: 8
+    symbol: O
+    name: Oxygen
+    group: 16
+    period: 2
+    molar_mass_g_mol: 15.999
+  - Z: 16
+    symbol: S
+    name: Sulfur
+    group: 16
+    period: 3
+    molar_mass_g_mol: 32.06
+  - Z: 26
+    symbol: Fe
+    name: Iron
+    group: 8
+    period: 4
+    molar_mass_g_mol: 55.845

--- a/configs/symbolic/molecules/spectroscopy.yaml
+++ b/configs/symbolic/molecules/spectroscopy.yaml
@@ -1,0 +1,38 @@
+molecules:
+  - id: h2o
+    name: Water
+    formula: H2O
+    spectral:
+      bands_um: [1.4, 1.9, 2.7, 6.3]
+      windows_um: [1.25, 1.65, 2.2]
+      references: ["HITRAN", "ExoMol"]
+    tags: [exoplanet, atmosphere, biosignature_candidate]
+  - id: co2
+    name: Carbon Dioxide
+    formula: CO2
+    spectral:
+      bands_um: [2.0, 2.7, 4.3, 15.0]
+      references: ["HITRAN", "GEISA"]
+    tags: [exoplanet, greenhouse]
+  - id: ch4
+    name: Methane
+    formula: CH4
+    spectral:
+      bands_um: [1.7, 2.3, 3.3, 7.7]
+      references: ["HITRAN", "ExoMol"]
+    tags: [exoplanet, reduced_atmospheres]
+  - id: o3
+    name: Ozone
+    formula: O3
+    spectral:
+      bands_um: [9.6]
+      lines_nm: [255]
+      references: ["HITRAN"]
+    tags: [biosignature_context]
+  - id: o2
+    name: Molecular Oxygen
+    formula: O2
+    spectral:
+      lines_nm: [690, 760] # A-band ~760 nm
+      references: ["HITRAN"]
+    tags: [biosignature_context]

--- a/configs/symbolic/molecules/symbolic_map.yaml
+++ b/configs/symbolic/molecules/symbolic_map.yaml
@@ -1,0 +1,17 @@
+version: 1
+mappings:
+  # Example: how downstream code should resolve symbolic IDs to engine plugins
+  - symbolic: h2o
+    resolves_to:
+      spectra_provider: "hitran"
+      cross_section_table: "H2O_2024.kxt"
+      opacities_model: "correlated_k"
+  - symbolic: co2
+    resolves_to:
+      spectra_provider: "hitran"
+      cross_section_table: "CO2_2024.kxt"
+      opacities_model: "correlated_k"
+  - symbolic: amino_acids
+    resolves_to:
+      table: "amino_acids.yaml"
+      loader: "biochem.loader:load_amino_acids"


### PR DESCRIPTION
## Summary
- add JSON schema and symbolic mapping for molecules
- define periodic elements, bonds, functional groups, amino acids
- include exoplanet spectroscopy dataset and README

## Testing
- `pre-commit run --files configs/symbolic/molecules/README.md configs/symbolic/molecules/_schemas/molecule.schema.json configs/symbolic/molecules/amino_acids.yaml configs/symbolic/molecules/bonds.yaml configs/symbolic/molecules/functional_groups.yaml configs/symbolic/molecules/periodic_table.yaml configs/symbolic/molecules/spectroscopy.yaml configs/symbolic/molecules/symbolic_map.yaml`
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `poetry run python -m spectramind --help` *(fails: ModuleNotFoundError: No module named 'typer')*
- `poetry run python -m spectramind selftest --fast` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_689df2438c6c832ab7e6239f6b715c16