### PR TITLE
Add symbolic override suites and validation utilities

### DIFF
--- a/configs/symbolic/README.md
+++ b/configs/symbolic/README.md
@@ -1,22 +1,10 @@
-# SpectraMind V50 — configs/symbolic Guide
+# Symbolic Configuration (SpectraMind V50)
 
-## How to use
-- Default entrypoint: `symbolic/base.yaml`
-- Compose with Hydra:
-  - `+symbolic.profile=leaderboard`
-  - `+symbolic.weights=strict`
-  - `+symbolic.regions=airs_regions`
-- Add/remove rules by editing defaults in `base.yaml` or via command-line group overrides.
+This subtree contains symbolic configuration for physics-/logic-aware constraints used across the SpectraMind V50 pipeline.
 
-## Key files
-- `rules/*.yaml` — individual rule configs merged under `symbolic.rules.*`
-- `profiles/*.yaml` — scenario presets; may override weights/toggles/caps
-- `weights/*.yaml` — per-rule weights collections
-- `molecules/*.yaml` — band templates (bins and/or wavelengths)
-- `regions/*.yaml` — named bin ranges used by rules for masking/boosting
-- `export.yaml` — output artifact locations
-- `debug.yaml` — logging verbosity and sampling
-- `schema/symbolic.schema.json` — sanity schema for CI checks
+- `rules/` (if present): Canonical symbolic rule packs (base truths; usually do not mutate frequently)
+- `molecules/`: Molecule-centric metadata/configs and region mappings
+- `overrides/`: Contextual override layers (competition, events, molecules) that are composed over the canonical packs
+- `profiles/` (if present): Profile definitions selecting subsets/weights of rules for different operating modes
 
-## Replace placeholders
-- Update `regions/airs_regions.yaml` and `molecules/lines_h2o_co2_ch4.yaml` with dataset-accurate bin or wavelength ranges once your wavelength↔bin CSV is finalized.
+> Policy: **immutable base + composable overrides**. Always update overrides first for scenario-specific needs.

--- a/configs/symbolic/overrides/README.md
+++ b/configs/symbolic/overrides/README.md
@@ -1,29 +1,15 @@
-# configs/symbolic/overrides
+# Symbolic Overrides
 
-This directory contains override packs that specialize the V50 symbolic system per planet, instrument, run-mode, or data quality. These YAMLs are composed via Hydra and routed using `routing.yaml` match rules on metadata (e.g., `meta.teq`, `meta.jitter_rms_px`, `meta.snr_db`).
-
-## Quick use
-- Default add-on: `+configs/symbolic/overrides/base`
-- Apply profiles: `+configs/symbolic/overrides/profiles/profile_high_jitter`
-- Add instrument overrides: `+configs/symbolic/overrides/instruments/fgs1_strict`
-- Auto-route by metadata: include `+configs/symbolic/overrides/routing` (engine selects).
+Override layers that modify or specialize canonical symbolic rules.
 
 ## Structure
-- `_schemas/overrides.schema.yaml` — soft schema to sanity-check keys.
-- `base.yaml` — conservative defaults (safe everywhere).
-- `routing.yaml` — metadata → override selection map (ordered rules).
-- `profiles/` — planet/data quality profiles (`hot_jupiter`, `low_snr`, `high_haze`, etc.).
-- `molecules/` — molecule-specific constraints & windows (`H2O`, `CO2`, `CH4`, `NH3`, `CO`).
-- `instruments/` — per-instrument constraint adjustments (`FGS1` strict, `AIRS` relaxed).
-- `events/` — transit vs eclipse specialization and cadence-aware toggles.
-- `weights/` — hard/soft weighting presets for symbolic terms.
-- `violations/` — allow/deny rule sets; emergency demotion/promotions during triage.
-- `competition/` — Kaggle runtime guardrails & 9h budget protections.
 
-## Log & diagnostics integration
+- `_schemas/`: JSON Schemas for validating override files
+- `events/`: Event-driven rule switching (mission phases, instrument states, pipeline triggers)
+- `competition/`: Leaderboard-safe hardening (time/compute caps, determinism, risk guards)
+- `molecules/`: Molecule-region attention and physics-aware emphasis (e.g., H2O / CO2 bands)
 
-These configs include:
-- `events_jsonl.enable` to emit run-time JSONL events.
-- `logs.rotate_mb` & `logs.max_files` to keep console + rotating file logs tidy.
-- MLflow/W&B toggles via environment variables (no-ops if disabled).
-- `diagnostics.flags.*` to surface overlays in the HTML dashboard.
+## Validation
+
+All YAML/JSON overrides are designed to be validated with the schemas in `_schemas/`. You can run
+your preferred JSON Schema validator (e.g., `ajv`, `python -m jsonschema`) during CI to enforce structure.

--- a/configs/symbolic/overrides/_schemas/competition_override.schema.json
+++ b/configs/symbolic/overrides/_schemas/competition_override.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Competition Override Schema",
+  "description": "Validate competition-mode symbolic overrides",
+  "type": "object",
+  "properties": {
+    "competition": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "mode": { "type": "string", "enum": ["strict", "balanced", "fast"] },
+        "guards": { "type": "object" },
+        "overrides": { "type": "object" }
+      },
+      "required": ["id", "name", "mode", "overrides"]
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "author": { "type": "string" },
+        "created": { "type": "string", "format": "date" },
+        "schema_version": { "type": "string" }
+      },
+      "required": ["schema_version"]
+    }
+  },
+  "required": ["competition", "metadata"]
+}

--- a/configs/symbolic/overrides/_schemas/event_override.schema.json
+++ b/configs/symbolic/overrides/_schemas/event_override.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Event Override Schema",
+  "description": "Validate event-driven symbolic overrides",
+  "type": "object",
+  "properties": {
+    "event": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "description": { "type": "string" },
+        "labels": { "type": "array", "items": { "type": "string" } },
+        "trigger_conditions": { "type": "array", "items": { "type": "object" }, "minItems": 1 },
+        "overrides": { "type": "object" },
+        "effective_dates": {
+          "type": "object",
+          "properties": {
+            "start": { "type": "string", "format": "date-time" },
+            "end": { "type": "string", "format": "date-time" }
+          },
+          "required": ["start"]
+        },
+        "priority": { "type": "integer", "minimum": 0 }
+      },
+      "required": ["id", "name", "trigger_conditions", "overrides"]
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "author": { "type": "string" },
+        "created": { "type": "string", "format": "date" },
+        "schema_version": { "type": "string" }
+      },
+      "required": ["schema_version"]
+    }
+  },
+  "required": ["event", "metadata"]
+}

--- a/configs/symbolic/overrides/_schemas/molecule_override.schema.json
+++ b/configs/symbolic/overrides/_schemas/molecule_override.schema.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Molecule Override Schema",
+  "description": "Validate molecule-centric symbolic overrides",
+  "type": "object",
+  "properties": {
+    "molecule": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "name": { "type": "string", "minLength": 1 },
+        "formula": { "type": "string", "minLength": 1 },
+        "bands_um": {
+          "type": "array",
+          "items": { "type": "array", "items": { "type": "number" }, "minItems": 2, "maxItems": 2 }
+        },
+        "overrides": { "type": "object" },
+        "notes": { "type": "string" }
+      },
+      "required": ["id", "name", "formula", "bands_um", "overrides"]
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "author": { "type": "string" },
+        "created": { "type": "string", "format": "date" },
+        "schema_version": { "type": "string" }
+      },
+      "required": ["schema_version"]
+    }
+  },
+  "required": ["molecule", "metadata"]
+}

--- a/configs/symbolic/overrides/competition/README.md
+++ b/configs/symbolic/overrides/competition/README.md
@@ -1,47 +1,6 @@
-# Competition Overrides (Hydra)
+# Competition Overrides
 
-This folder contains mission-grade Hydra override packs tuned for the NeurIPS 2025 Ariel Data Challenge. They do not change base schema/structure—they only override values for symbolic constraints, calibration, uncertainty, runtime guardrails, and diagnostics.
-
-## How to select an override
-
-Pick one of these when you call the CLI (examples shown for Typer; works with `python -m spectramind` as well):
-
-- **Leaderboard** (full fidelity, strict constraints & COREL):
-
-```bash
-python -m spectramind submit +symbolic/overrides=competition/leaderboard
-```
-
-- **Kaggle GPU** (9-hour guardrail, tight logging, compact diagnostics):
-
-```bash
-python -m spectramind submit +symbolic/overrides=competition/kaggle_gpu
-```
-
-- **Local GPU** (developer machine, more diagnostics):
-
-```bash
-python -m spectramind train +symbolic/overrides=competition/local_gpu
-```
-
-- **Fast Debug** (minutes, reduced weights, tiny batches, quick dashboard):
-
-```bash
-python -m spectramind diagnose dashboard +symbolic/overrides=competition/fast_debug
-```
-
-## Files
-
-- `leaderboard.yaml` — max quality, stricter symbolic + COREL coverage targets, calibrated σ export.
-- `kaggle_gpu.yaml` — 9h walltime guardrail, reduced dashboard payload, artifact quotas enforced.
-- `local_gpu.yaml` — dev-friendly logging/diagnostics; higher verbosity.
-- `fast_debug.yaml` — quick iteration; tiny data slices; soft symbolic weights.
-- `rules_strict.yaml` — strict symbolic rule set (referenced by leaderboard).
-- `rules_minimal.yaml` — minimal but sane rules; used by fast_debug.
-- `profiles.yaml` — symbolic profile catalog (molecule bands, detector regions, priors).
-- `uncertainty.yaml` — σ decoder and export policy overrides.
-- `calibration.yaml` — temperature scaling + COREL options, coverage & reporting.
-- `corel.yaml` — COREL GNN backend, edge features, positional encodings.
-- `runtime.yaml` — guardrails, logging (JSONL + rotating files), artifact quotas, CI flags.
-
-These work as value overlays. Your base configs remain the source of truth; choose exactly one of the competition packs to layer on top per run.
+Leaderboard-safe constraints and guardrails for challenge execution:
+- Determinism & reproducibility (seed, AMP mode, checkpoint cadence)
+- Runtime & memory caps (batch sizing, workers, cache policy)
+- Conservative uncertainty behavior to avoid overconfidence penalties

--- a/configs/symbolic/overrides/competition/balanced_competition.yaml
+++ b/configs/symbolic/overrides/competition/balanced_competition.yaml
@@ -1,0 +1,37 @@
+# Competition override — BALANCED mode
+competition:
+  id: COMP-BAL-001
+  name: "Competition Balanced"
+  description: "Balanced accuracy/speed/robustness for daily runs"
+  mode: balanced
+  guards:
+    determinism:
+      seed: 2025
+      cudnn_deterministic: true
+      cudnn_benchmark: false
+      allow_tf32: true
+      amp: "bf16"
+    runtime:
+      max_hours: 9.0
+      num_workers: 4
+      prefetch_factor: 4
+      pin_memory: true
+      batch_size_infer: 12
+      batch_size_train: 24
+    memory:
+      gradient_checkpointing: true
+      activation_offload: false
+  overrides:
+    symbolic_constraints:
+      nonnegativity_weight: 1.1
+      smoothness_weight: 1.0
+      molecular_coherence_weight: 1.1
+    calibration:
+      corel_enabled: true
+      temperature_scaling: 0.98
+    uncertainty:
+      sigma_floor: 0.025
+metadata:
+  author: "SpectraMind Architect"
+  created: "2025-08-14"
+  schema_version: "1.0"

--- a/configs/symbolic/overrides/competition/strict_competition.json
+++ b/configs/symbolic/overrides/competition/strict_competition.json
@@ -1,0 +1,48 @@
+{
+  "competition": {
+    "id": "COMP-STRICT-001",
+    "name": "Competition Strict",
+    "description": "Hardened config for leaderboard submissions with maximum determinism",
+    "mode": "strict",
+    "guards": {
+      "determinism": {
+        "seed": 1337,
+        "cudnn_deterministic": true,
+        "cudnn_benchmark": false,
+        "allow_tf32": false,
+        "amp": "fp16"
+      },
+      "runtime": {
+        "max_hours": 9.0,
+        "num_workers": 2,
+        "prefetch_factor": 2,
+        "pin_memory": true,
+        "batch_size_infer": 8,
+        "batch_size_train": 16
+      },
+      "memory": {
+        "gradient_checkpointing": true,
+        "activation_offload": false
+      }
+    },
+    "overrides": {
+      "symbolic_constraints": {
+        "nonnegativity_weight": 1.2,
+        "smoothness_weight": 1.1,
+        "molecular_coherence_weight": 1.0
+      },
+      "calibration": {
+        "corel_enabled": true,
+        "temperature_scaling": 1.0
+      },
+      "uncertainty": {
+        "sigma_floor": 0.03
+      }
+    }
+  },
+  "metadata": {
+    "author": "SpectraMind Architect",
+    "created": "2025-08-14",
+    "schema_version": "1.0"
+  }
+}

--- a/configs/symbolic/overrides/competition/strict_competition.yaml
+++ b/configs/symbolic/overrides/competition/strict_competition.yaml
@@ -1,0 +1,37 @@
+# Competition override — STRICT mode
+competition:
+  id: COMP-STRICT-001
+  name: "Competition Strict"
+  description: "Hardened config for leaderboard submissions with maximum determinism"
+  mode: strict
+  guards:
+    determinism:
+      seed: 1337
+      cudnn_deterministic: true
+      cudnn_benchmark: false
+      allow_tf32: false
+      amp: "fp16"          # lock AMP mode; ensure consistent kernels
+    runtime:
+      max_hours: 9.0       # challenge guardrail
+      num_workers: 2
+      prefetch_factor: 2
+      pin_memory: true
+      batch_size_infer: 8
+      batch_size_train: 16
+    memory:
+      gradient_checkpointing: true
+      activation_offload: false
+  overrides:
+    symbolic_constraints:
+      nonnegativity_weight: 1.2
+      smoothness_weight: 1.1
+      molecular_coherence_weight: 1.0
+    calibration:
+      corel_enabled: true
+      temperature_scaling: 1.00
+    uncertainty:
+      sigma_floor: 0.03
+metadata:
+  author: "SpectraMind Architect"
+  created: "2025-08-14"
+  schema_version: "1.0"

--- a/configs/symbolic/overrides/events/README.md
+++ b/configs/symbolic/overrides/events/README.md
@@ -1,0 +1,8 @@
+# Event-Driven Overrides
+
+Use these when symbolic rule weights, constraint toggles, or calibration modes should change based on:
+- Mission or observation phase (e.g., primary transit, secondary eclipse)
+- Instrument state (e.g., FGS lock, AIRS detector heater cycle, jitter excursions)
+- Pipeline triggers (e.g., post-calibration, conformalization on/off, anomaly recovery)
+
+Each file adheres to `_schemas/event_override.schema.json`. CI can validate them before merge.

--- a/configs/symbolic/overrides/events/example_anomaly_recovery.yaml
+++ b/configs/symbolic/overrides/events/example_anomaly_recovery.yaml
@@ -1,0 +1,28 @@
+# Event override — Post-anomaly recovery (tighten smoothness, raise sigma floor)
+event:
+  id: EVT-POST-ANOMALY-RECOVERY
+  name: "Post-Anomaly Recovery Window"
+  description: "Temporary conservative settings after instrument anomaly or jitter excursion"
+  labels: ["recovery", "conservative"]
+  trigger_conditions:
+    - pipeline_marker: "anomaly_recovered"
+    - instrument_state: "FGS_LOCK_RESTORED"
+  overrides:
+    symbolic_constraints:
+      smoothness_weight: 1.3
+      molecular_coherence_weight: 0.9
+      nonnegativity_weight: 1.1
+      asymmetry_weight: 1.1
+    calibration:
+      corel_enabled: true
+      temperature_scaling: 1.05
+    uncertainty:
+      scale: 1.1
+      sigma_floor: 0.05
+  effective_dates:
+    start: "2025-08-14T00:00:00Z"
+  priority: 50
+metadata:
+  author: "SpectraMind Architect"
+  created: "2025-08-14"
+  schema_version: "1.0"

--- a/configs/symbolic/overrides/events/example_transit_event.json
+++ b/configs/symbolic/overrides/events/example_transit_event.json
@@ -1,0 +1,40 @@
+{
+  "event": {
+    "id": "EVT-TRANSIT-001",
+    "name": "Hot Jupiter Primary Transit",
+    "description": "Override constraints for high-SNR, feature-rich primary transit",
+    "labels": ["transit", "AIRS", "hot-jupiter"],
+    "trigger_conditions": [
+      { "phase": "primary_transit" },
+      { "instrument": "AIRS" },
+      { "target_type": "Hot Jupiter" },
+      { "wavelength_range_um": [1.95, 7.8] }
+    ],
+    "overrides": {
+      "symbolic_constraints": {
+        "smoothness_weight": 0.7,
+        "molecular_coherence_weight": 1.25,
+        "nonnegativity_weight": 1.0,
+        "asymmetry_weight": 0.9
+      },
+      "calibration": {
+        "corel_enabled": true,
+        "temperature_scaling": 0.95
+      },
+      "uncertainty": {
+        "scale": 0.9,
+        "sigma_floor": 0.02
+      }
+    },
+    "effective_dates": {
+      "start": "2025-08-14T00:00:00Z",
+      "end": "2025-08-14T23:59:59Z"
+    },
+    "priority": 10
+  },
+  "metadata": {
+    "author": "SpectraMind Architect",
+    "created": "2025-08-14",
+    "schema_version": "1.0"
+  }
+}

--- a/configs/symbolic/overrides/events/example_transit_event.yaml
+++ b/configs/symbolic/overrides/events/example_transit_event.yaml
@@ -1,0 +1,34 @@
+# Event override — Hot Jupiter primary transit (AIRS focus)
+event:
+  id: EVT-TRANSIT-001
+  name: "Hot Jupiter Primary Transit"
+  description: "Override constraints for high-SNR, feature-rich primary transit"
+  labels: ["transit", "AIRS", "hot-jupiter"]
+  trigger_conditions:
+    - phase: "primary_transit"      # required mission phase
+    - instrument: "AIRS"            # AIRS is main spectral source here
+    - target_type: "Hot Jupiter"    # planetary class
+    - wavelength_range_um: [1.95, 7.8]
+  overrides:
+    symbolic_constraints:
+      # Slightly relax smoothness to preserve narrow features; increase molecular coherence
+      smoothness_weight: 0.7
+      molecular_coherence_weight: 1.25
+      nonnegativity_weight: 1.0
+      asymmetry_weight: 0.9
+    calibration:
+      # Enable conformal calibration; mild temperature scaling on σ
+      corel_enabled: true
+      temperature_scaling: 0.95
+    uncertainty:
+      # Encourage tighter σ where SNR is high; cap floor to avoid overconfidence
+      scale: 0.9
+      sigma_floor: 0.02
+  effective_dates:
+    start: "2025-08-14T00:00:00Z"
+    end: "2025-08-14T23:59:59Z"
+  priority: 10
+metadata:
+  author: "SpectraMind Architect"
+  created: "2025-08-14"
+  schema_version: "1.0"

--- a/configs/symbolic/overrides/molecules/README.md
+++ b/configs/symbolic/overrides/molecules/README.md
@@ -1,0 +1,4 @@
+# Molecule-Centric Overrides
+
+Use to emphasize or de-emphasize constraints/weights in spectral regions associated with target molecules.
+Each config defines bands (μm) and an override block (weights, calibration, uncertainty preferences).

--- a/configs/symbolic/overrides/molecules/ch4_focus.yaml
+++ b/configs/symbolic/overrides/molecules/ch4_focus.yaml
@@ -1,0 +1,25 @@
+# Molecule override — Methane (CH4) emphasis
+molecule:
+  id: MOL-CH4-001
+  name: "Methane"
+  formula: "CH4"
+  bands_um:
+    - [2.1, 2.5]
+    - [3.1, 3.6]
+    - [7.3, 7.8]
+  overrides:
+    symbolic_constraints:
+      molecular_coherence_weight: 1.35
+      smoothness_weight: 0.9
+      nonnegativity_weight: 1.0
+    calibration:
+      corel_enabled: true
+      temperature_scaling: 0.98
+    uncertainty:
+      band_sigma_scale: 0.9
+      sigma_floor: 0.02
+  notes: "CH4 prominent around 3.3 μm; permit narrower features by easing smoothness slightly."
+metadata:
+  author: "SpectraMind Architect"
+  created: "2025-08-14"
+  schema_version: "1.0"

--- a/configs/symbolic/overrides/molecules/co2_focus.yaml
+++ b/configs/symbolic/overrides/molecules/co2_focus.yaml
@@ -1,0 +1,24 @@
+# Molecule override — Carbon Dioxide (CO2) emphasis
+molecule:
+  id: MOL-CO2-001
+  name: "Carbon Dioxide"
+  formula: "CO2"
+  bands_um:
+    - [1.95, 2.2]
+    - [4.1, 4.5]
+  overrides:
+    symbolic_constraints:
+      molecular_coherence_weight: 1.3
+      smoothness_weight: 0.95
+      nonnegativity_weight: 1.0
+    calibration:
+      corel_enabled: true
+      temperature_scaling: 0.99
+    uncertainty:
+      band_sigma_scale: 0.92
+      sigma_floor: 0.02
+  notes: "CO2 fundamental near 4.3 μm; adjust weights to respect sharper structure."
+metadata:
+  author: "SpectraMind Architect"
+  created: "2025-08-14"
+  schema_version: "1.0"

--- a/configs/symbolic/overrides/molecules/h2o_focus.json
+++ b/configs/symbolic/overrides/molecules/h2o_focus.json
@@ -1,0 +1,29 @@
+{
+  "molecule": {
+    "id": "MOL-H2O-001",
+    "name": "Water Vapor",
+    "formula": "H2O",
+    "bands_um": [[1.9, 2.1], [2.5, 3.2], [5.5, 7.2]],
+    "overrides": {
+      "symbolic_constraints": {
+        "molecular_coherence_weight": 1.35,
+        "smoothness_weight": 0.9,
+        "nonnegativity_weight": 1.0
+      },
+      "calibration": {
+        "corel_enabled": true,
+        "temperature_scaling": 0.97
+      },
+      "uncertainty": {
+        "band_sigma_scale": 0.9,
+        "sigma_floor": 0.02
+      }
+    },
+    "notes": "Emphasize H2O-sensitive regions; allow slightly lower smoothness to retain narrow lines."
+  },
+  "metadata": {
+    "author": "SpectraMind Architect",
+    "created": "2025-08-14",
+    "schema_version": "1.0"
+  }
+}

--- a/configs/symbolic/overrides/molecules/h2o_focus.yaml
+++ b/configs/symbolic/overrides/molecules/h2o_focus.yaml
@@ -1,0 +1,27 @@
+# Molecule override — Water vapor (H2O) emphasis
+molecule:
+  id: MOL-H2O-001
+  name: "Water Vapor"
+  formula: "H2O"
+  # Select representative bands in AIRS coverage; refine with instrument line lists as needed
+  bands_um:
+    - [1.9, 2.1]
+    - [2.5, 3.2]
+    - [5.5, 7.2]
+  overrides:
+    symbolic_constraints:
+      molecular_coherence_weight: 1.35
+      smoothness_weight: 0.9
+      nonnegativity_weight: 1.0
+    calibration:
+      corel_enabled: true
+      temperature_scaling: 0.97
+    uncertainty:
+      # Encourage higher confidence within targeted bands while preserving a safe floor
+      band_sigma_scale: 0.9
+      sigma_floor: 0.02
+  notes: "Emphasize H2O-sensitive regions; allow slightly lower smoothness to retain narrow lines."
+metadata:
+  author: "SpectraMind Architect"
+  created: "2025-08-14"
+  schema_version: "1.0"

--- a/configs/symbolic/overrides/validate_overrides_locally.py
+++ b/configs/symbolic/overrides/validate_overrides_locally.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+# Quick local validator using jsonschema (pip install jsonschema pyyaml)
+import json
+import pathlib
+import sys
+
+import yaml
+from jsonschema import Draft7Validator, validate
+
+ROOT = pathlib.Path(__file__).resolve().parent
+SCHEMAS = {
+    "events": ROOT / "_schemas" / "event_override.schema.json",
+    "competition": ROOT / "_schemas" / "competition_override.schema.json",
+    "molecules": ROOT / "_schemas" / "molecule_override.schema.json",
+}
+
+
+def load_json(p):
+    return json.loads(pathlib.Path(p).read_text())
+
+
+def load_yaml(p):
+    return yaml.safe_load(pathlib.Path(p).read_text())
+
+
+def run_validate(schema_path, doc_path):
+    schema = load_json(schema_path)
+    doc = load_json(doc_path) if str(doc_path).endswith(".json") else load_yaml(doc_path)
+    Draft7Validator.check_schema(schema)
+    validate(instance=doc, schema=schema)
+    print(f"OK: {doc_path}")
+
+
+def main():
+    targets = [
+        (SCHEMAS["events"], ROOT / "events" / "example_transit_event.yaml"),
+        (SCHEMAS["events"], ROOT / "events" / "example_transit_event.json"),
+        (SCHEMAS["events"], ROOT / "events" / "example_anomaly_recovery.yaml"),
+        (SCHEMAS["competition"], ROOT / "competition" / "strict_competition.yaml"),
+        (SCHEMAS["competition"], ROOT / "competition" / "balanced_competition.yaml"),
+        (SCHEMAS["competition"], ROOT / "competition" / "strict_competition.json"),
+        (SCHEMAS["molecules"], ROOT / "molecules" / "h2o_focus.yaml"),
+        (SCHEMAS["molecules"], ROOT / "molecules" / "co2_focus.yaml"),
+        (SCHEMAS["molecules"], ROOT / "molecules" / "ch4_focus.yaml"),
+        (SCHEMAS["molecules"], ROOT / "molecules" / "h2o_focus.json"),
+    ]
+    try:
+        for schema, doc in targets:
+            run_validate(schema, doc)
+        print("All validations passed.")
+    except Exception as e:
+        print(f"Validation failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document symbolic config and override structure
- add JSON schemas for event, competition and molecule override files
- provide example overrides for events, competition modes and key molecules
- include a local validator script for override files

## Testing
- `pre-commit run --files configs/symbolic/README.md configs/symbolic/overrides/README.md configs/symbolic/overrides/_schemas/event_override.schema.json configs/symbolic/overrides/_schemas/competition_override.schema.json configs/symbolic/overrides/_schemas/molecule_override.schema.json configs/symbolic/overrides/events/README.md configs/symbolic/overrides/events/example_transit_event.yaml configs/symbolic/overrides/events/example_transit_event.json configs/symbolic/overrides/events/example_anomaly_recovery.yaml configs/symbolic/overrides/competition/README.md configs/symbolic/overrides/competition/strict_competition.yaml configs/symbolic/overrides/competition/balanced_competition.yaml configs/symbolic/overrides/competition/strict_competition.json configs/symbolic/overrides/molecules/README.md configs/symbolic/overrides/molecules/h2o_focus.yaml configs/symbolic/overrides/molecules/co2_focus.yaml configs/symbolic/overrides/molecules/ch4_focus.yaml configs/symbolic/overrides/molecules/h2o_focus.json configs/symbolic/overrides/validate_overrides_locally.py`
- `python3 configs/symbolic/overrides/validate_overrides_locally.py`


------
https://chatgpt.com/codex/tasks/task_e_689e5387950c832a9e738d8bf4b2ea07