### PR TITLE
feat(configs): add instrument override suite with schemas and validation

### DIFF
--- a/.github/workflows/validate-symbolic-configs.yml
+++ b/.github/workflows/validate-symbolic-configs.yml
@@ -1,0 +1,29 @@
+name: Validate Symbolic Configs
+
+on:
+  push:
+    paths:
+      - 'configs/symbolic/**'
+      - 'tools/validate_configs.py'
+  pull_request:
+    paths:
+      - 'configs/symbolic/**'
+      - 'tools/validate_configs.py'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install jsonschema pyyaml
+      - name: Validate
+        run: |
+          python tools/validate_configs.py

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+.PHONY: validate-instruments
+validate-instruments:
+	@python3 tools/validate_configs.py

--- a/configs/symbolic/README.md
+++ b/configs/symbolic/README.md
@@ -1,10 +1,9 @@
-# Symbolic Configuration (SpectraMind V50)
+# symbolic configs
 
-This subtree contains symbolic configuration for physics-/logic-aware constraints used across the SpectraMind V50 pipeline.
+Symbolic, stable entry points for pipeline configuration. Treat `index.yaml` as the public API.
+Modules under `instruments/` define concrete instrument profiles validated by `instrument.schema.yaml`.
 
-- `rules/` (if present): Canonical symbolic rule packs (base truths; usually do not mutate frequently)
-- `molecules/`: Molecule-centric metadata/configs and region mappings
-- `overrides/`: Contextual override layers (competition, events, molecules) that are composed over the canonical packs
-- `profiles/` (if present): Profile definitions selecting subsets/weights of rules for different operating modes
-
-> Policy: **immutable base + composable overrides**. Always update overrides first for scenario-specific needs.
+Usage (Hydra-style):
+- Select via alias: `python -m spectramind +instrument=@ariel_airs`
+- Or direct path: `python -m spectramind +instrument=instruments/ariel/airs`
+- Apply an override bundle: `python -m spectramind -c configs/symbolic/overrides/instruments/dev-ariel`

--- a/configs/symbolic/index.yaml
+++ b/configs/symbolic/index.yaml
@@ -1,0 +1,7 @@
+# Central alias map for symbolic components (Hydra-safe)
+aliases:
+  # Instrument profiles
+  ariel_airs: instruments/ariel/airs
+  ariel_fgs: instruments/ariel/fgs
+  jwst_nirspec: instruments/jwst/nirspec
+  sim_ideal: instruments/simulated/ideal

--- a/configs/symbolic/instruments/README.md
+++ b/configs/symbolic/instruments/README.md
@@ -1,0 +1,8 @@
+# instruments
+
+Concrete instrument profiles. Each file should validate against `instrument.schema.yaml`.
+
+Conventions
+- Wavelengths in microns (μm), resolutions as λ/Δλ at reference λ.
+- Noise terms are RMS per exposure unless specified.
+- `calibration` fields are paths (relative to repo) or identifiers resolvable by your data loader.

--- a/configs/symbolic/instruments/ariel/airs.yaml
+++ b/configs/symbolic/instruments/ariel/airs.yaml
@@ -1,0 +1,33 @@
+name: "ARIEL AIRS (proto)"
+telescope:
+  aperture_m: 1.0
+  f_number: 13.0
+  optical_efficiency: 0.28
+spectral_range_um: [1.95, 7.8]
+channels:
+  - name: NIR-S
+    range_um: [1.95, 3.9]
+    resolving_power: 100
+    dispersion: prism
+  - name: MIR-S
+    range_um: [3.9, 7.8]
+    resolving_power: 50
+    dispersion: prism
+detectors:
+  type: "HgCdTe"
+  pixel_scale_arcsec: 0.3
+  read_noise_e: 10.0
+  dark_current_e_s: 0.005
+  saturation_ke: 120.0
+modes: ["transit", "eclipse", "phasecurve"]
+pointing:
+  rms_jitter_arcsec: 0.18
+  long_drift_arcsec: 0.07
+photometry:
+  precision_ppm_1hr: 30
+  cadence_s: 10
+  throughput_curve: "cal/throughputs/ariel/airs_throughput.csv"
+calibration:
+  flat: "cal/flat/ariel/airs_flat_v0.fits"
+  dark: "cal/dark/ariel/airs_dark_v0.fits"
+  wavelength: "cal/wave/ariel/airs_wave_v0.json"

--- a/configs/symbolic/instruments/ariel/fgs.yaml
+++ b/configs/symbolic/instruments/ariel/fgs.yaml
@@ -1,0 +1,33 @@
+name: "ARIEL FGS (proto)"
+telescope:
+  aperture_m: 1.0
+  f_number: 13.0
+  optical_efficiency: 0.35
+spectral_range_um: [0.5, 1.1]
+channels:
+  - name: VIS
+    range_um: [0.5, 0.8]
+    resolving_power: 10
+    dispersion: photometer
+  - name: NIR
+    range_um: [0.8, 1.1]
+    resolving_power: 10
+    dispersion: photometer
+detectors:
+  type: "CCD"
+  pixel_scale_arcsec: 0.2
+  read_noise_e: 4.0
+  dark_current_e_s: 0.001
+  saturation_ke: 150.0
+modes: ["guiding", "photometry"]
+pointing:
+  rms_jitter_arcsec: 0.18
+  long_drift_arcsec: 0.07
+photometry:
+  precision_ppm_1hr: 50
+  cadence_s: 1
+  throughput_curve: "cal/throughputs/ariel/fgs_throughput.csv"
+calibration:
+  flat: "cal/flat/ariel/fgs_flat_v0.fits"
+  dark: "cal/dark/ariel/fgs_dark_v0.fits"
+  wavelength: "cal/wave/ariel/fgs_wave_v0.json"

--- a/configs/symbolic/instruments/instrument.schema.yaml
+++ b/configs/symbolic/instruments/instrument.schema.yaml
@@ -1,0 +1,66 @@
+$schema: "https://json-schema.org/draft/2020-12/schema"
+title: InstrumentProfile
+type: object
+required: [name, telescope, spectral_range_um, channels, detectors, modes, pointing, photometry, calibration]
+properties:
+  name: {type: string}
+  telescope:
+    type: object
+    required: [aperture_m, f_number, optical_efficiency]
+    properties:
+      aperture_m: {type: number}
+      f_number: {type: number}
+      optical_efficiency: {type: number, minimum: 0, maximum: 1}
+  spectral_range_um:
+    type: array
+    items: {type: number}
+    minItems: 2
+    maxItems: 2
+  channels:
+    type: array
+    minItems: 1
+    items:
+      type: object
+      required: [name, range_um, resolving_power, dispersion]
+      properties:
+        name: {type: string}
+        range_um:
+          type: array
+          items: {type: number}
+          minItems: 2
+          maxItems: 2
+        resolving_power: {type: number}
+        dispersion: {type: string}
+  detectors:
+    type: object
+    required: [type, pixel_scale_arcsec, read_noise_e, dark_current_e_s, saturation_ke]
+    properties:
+      type: {type: string}
+      pixel_scale_arcsec: {type: number}
+      read_noise_e: {type: number}
+      dark_current_e_s: {type: number}
+      saturation_ke: {type: number}
+  modes:
+    type: array
+    items: {type: string}
+  pointing:
+    type: object
+    required: [rms_jitter_arcsec, long_drift_arcsec]
+    properties:
+      rms_jitter_arcsec: {type: number}
+      long_drift_arcsec: {type: number}
+  photometry:
+    type: object
+    required: [precision_ppm_1hr, cadence_s, throughput_curve]
+    properties:
+      precision_ppm_1hr: {type: number}
+      cadence_s: {type: number}
+      throughput_curve: {type: string}
+  calibration:
+    type: object
+    required: [flat, dark, wavelength]
+    properties:
+      flat: {type: string}
+      dark: {type: string}
+      wavelength: {type: string}
+additionalProperties: false

--- a/configs/symbolic/instruments/jwst/nirspec.yaml
+++ b/configs/symbolic/instruments/jwst/nirspec.yaml
@@ -1,0 +1,29 @@
+name: "JWST NIRSpec (bench)"
+telescope:
+  aperture_m: 6.5
+  f_number: 20.0
+  optical_efficiency: 0.35
+spectral_range_um: [0.7, 5.3]
+channels:
+  - name: PRISM
+    range_um: [0.7, 5.3]
+    resolving_power: 100
+    dispersion: prism
+detectors:
+  type: "HgCdTe"
+  pixel_scale_arcsec: 0.1
+  read_noise_e: 6.0
+  dark_current_e_s: 0.005
+  saturation_ke: 80.0
+modes: ["transit", "eclipse"]
+pointing:
+  rms_jitter_arcsec: 0.007
+  long_drift_arcsec: 0.01
+photometry:
+  precision_ppm_1hr: 15
+  cadence_s: 5
+  throughput_curve: "cal/throughputs/jwst/nirspec_throughput.csv"
+calibration:
+  flat: "cal/flat/jwst/nirspec_flat_v0.fits"
+  dark: "cal/dark/jwst/nirspec_dark_v0.fits"
+  wavelength: "cal/wave/jwst/nirspec_wave_v0.json"

--- a/configs/symbolic/instruments/simulated/ideal.yaml
+++ b/configs/symbolic/instruments/simulated/ideal.yaml
@@ -1,0 +1,29 @@
+name: "Simulated Ideal Spectrograph"
+telescope:
+  aperture_m: 1.2
+  f_number: 12.0
+  optical_efficiency: 0.9
+spectral_range_um: [1.0, 3.0]
+channels:
+  - name: IDEAL
+    range_um: [1.0, 3.0]
+    resolving_power: 120
+    dispersion: grating
+detectors:
+  type: "Ideal"
+  pixel_scale_arcsec: 0.25
+  read_noise_e: 0.0
+  dark_current_e_s: 0.0
+  saturation_ke: 1000.0
+modes: ["transit", "eclipse", "phasecurve"]
+pointing:
+  rms_jitter_arcsec: 0.0
+  long_drift_arcsec: 0.0
+photometry:
+  precision_ppm_1hr: 1.0
+  cadence_s: 5
+  throughput_curve: "cal/throughputs/simulated/ideal_flat_1.0.csv"
+calibration:
+  flat: "cal/flat/sim/ideal_flat.fits"
+  dark: "cal/dark/sim/ideal_dark.fits"
+  wavelength: "cal/wave/sim/ideal_wave.json"

--- a/configs/symbolic/overrides/_schemas/instrument_override.schema.json
+++ b/configs/symbolic/overrides/_schemas/instrument_override.schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Instrument Override Bundle",
+  "description": "Hydra-friendly override bundle that selects an instrument and tweaks runtime/physics knobs.",
+  "type": "object",
+  "properties": {
+    "defaults": {
+      "type": "array",
+      "items": { "type": "object" },
+      "minItems": 1
+    },
+    "run": {
+      "type": "object",
+      "properties": {
+        "mode": { "type": "string", "enum": ["transit", "eclipse", "phasecurve", "guiding"] },
+        "tag": { "type": "string" }
+      },
+      "required": ["mode"]
+    },
+    "instrument_tweaks": {
+      "type": "object",
+      "properties": {
+        "cadence_s": { "type": "number" },
+        "extra_white_noise_ppm": { "type": "number" },
+        "jitter_scale": { "type": "number" },
+        "downsample_R_factor": { "type": "number", "minimum": 0.1, "maximum": 1.0 },
+        "bin_time_s": { "type": "number" }
+      }
+    },
+    "benchmark": {
+      "type": "object",
+      "properties": {
+        "target_mag": { "type": "number" },
+        "exposure_s": { "type": "number" }
+      }
+    },
+    "stress": {
+      "type": "object",
+      "properties": {
+        "add_jitter_arcsec": { "type": "number" },
+        "telemetry_dropout_frac": { "type": "number", "minimum": 0, "maximum": 0.5 },
+        "thermal_drift_arcsec": { "type": "number" }
+      }
+    },
+    "recovery": {
+      "type": "object",
+      "properties": {
+        "sigma_floor": { "type": "number" },
+        "temperature_scaling": { "type": "number" }
+      }
+    },
+    "qa": {
+      "type": "object",
+      "properties": {
+        "enable_linearity_test": { "type": "boolean" },
+        "enable_dark_subtraction_test": { "type": "boolean" },
+        "enable_wave_regression": { "type": "boolean" }
+      }
+    }
+  },
+  "required": ["defaults", "run"]
+}

--- a/configs/symbolic/overrides/instruments/README.md
+++ b/configs/symbolic/overrides/instruments/README.md
@@ -1,0 +1,11 @@
+# instrument override bundles
+
+Import with Hydra `-c` or your CLI's config flag. Examples:
+- Dev ARIEL transit: `-c configs/symbolic/overrides/instruments/dev-ariel`
+- JWST benchmark:    `-c configs/symbolic/overrides/instruments/jwst-benchmark`
+- Fast simulation:   `-c configs/symbolic/overrides/instruments/fast-sim`
+- Jitter stress:     `-c configs/symbolic/overrides/instruments/jitter-stress`
+- Thermal drift:     `-c configs/symbolic/overrides/instruments/thermal-drift`
+- Recovery (safe):   `-c configs/symbolic/overrides/instruments/recovery-safe`
+- QA battery:        `-c configs/symbolic/overrides/instruments/qa-battery`
+- FGS guiding:       `-c configs/symbolic/overrides/instruments/fgs-guiding`

--- a/configs/symbolic/overrides/instruments/dev-ariel.yaml
+++ b/configs/symbolic/overrides/instruments/dev-ariel.yaml
@@ -1,0 +1,11 @@
+# Development-friendly ARIEL AIRS profile for transit spectroscopy
+defaults:
+  - override /instrument: instruments/ariel/airs
+
+run:
+  mode: "transit"
+  tag: "dev-ariel"
+instrument_tweaks:
+  cadence_s: 8
+  extra_white_noise_ppm: 10
+  jitter_scale: 1.0

--- a/configs/symbolic/overrides/instruments/fast-sim.yaml
+++ b/configs/symbolic/overrides/instruments/fast-sim.yaml
@@ -1,0 +1,10 @@
+# Lightning-fast runs with idealized instrument
+defaults:
+  - override /instrument: instruments/simulated/ideal
+
+run:
+  mode: "transit"
+  tag: "fast-sim"
+instrument_tweaks:
+  downsample_R_factor: 0.5
+  bin_time_s: 20

--- a/configs/symbolic/overrides/instruments/fgs-guiding.yaml
+++ b/configs/symbolic/overrides/instruments/fgs-guiding.yaml
@@ -1,0 +1,9 @@
+# Guiding-focused profile for FGS photometry characterization
+defaults:
+  - override /instrument: instruments/ariel/fgs
+
+run:
+  mode: "guiding"
+  tag: "fgs-guiding"
+instrument_tweaks:
+  cadence_s: 1

--- a/configs/symbolic/overrides/instruments/jitter-stress.yaml
+++ b/configs/symbolic/overrides/instruments/jitter-stress.yaml
@@ -1,0 +1,11 @@
+# Deliberately add pointing jitter to test robustness
+defaults:
+  - override /instrument: instruments/ariel/airs
+
+run:
+  mode: "transit"
+  tag: "jitter-stress"
+stress:
+  add_jitter_arcsec: 0.15
+instrument_tweaks:
+  extra_white_noise_ppm: 20

--- a/configs/symbolic/overrides/instruments/jwst-benchmark.yaml
+++ b/configs/symbolic/overrides/instruments/jwst-benchmark.yaml
@@ -1,0 +1,10 @@
+# Benchmark against JWST NIRSpec-like prism mode
+defaults:
+  - override /instrument: instruments/jwst/nirspec
+
+run:
+  mode: "eclipse"
+  tag: "jwst-bench"
+benchmark:
+  target_mag: 9.5
+  exposure_s: 10

--- a/configs/symbolic/overrides/instruments/qa-battery.yaml
+++ b/configs/symbolic/overrides/instruments/qa-battery.yaml
@@ -1,0 +1,13 @@
+# Quick quality-assurance checks for calibration pathways
+defaults:
+  - override /instrument: instruments/ariel/airs
+
+run:
+  mode: "transit"
+  tag: "qa-battery"
+qa:
+  enable_linearity_test: true
+  enable_dark_subtraction_test: true
+  enable_wave_regression: true
+instrument_tweaks:
+  cadence_s: 10

--- a/configs/symbolic/overrides/instruments/recovery-safe.yaml
+++ b/configs/symbolic/overrides/instruments/recovery-safe.yaml
@@ -1,0 +1,12 @@
+# Conservative settings for post-anomaly recovery
+defaults:
+  - override /instrument: instruments/ariel/airs
+
+run:
+  mode: "transit"
+  tag: "recovery-safe"
+recovery:
+  sigma_floor: 0.05
+  temperature_scaling: 1.05
+instrument_tweaks:
+  cadence_s: 12

--- a/configs/symbolic/overrides/instruments/thermal-drift.yaml
+++ b/configs/symbolic/overrides/instruments/thermal-drift.yaml
@@ -1,0 +1,11 @@
+# Simulate slow thermal drift (e.g., long observation drift)
+defaults:
+  - override /instrument: instruments/ariel/airs
+
+run:
+  mode: "phasecurve"
+  tag: "thermal-drift"
+stress:
+  thermal_drift_arcsec: 0.05
+instrument_tweaks:
+  bin_time_s: 30

--- a/tools/validate_configs.py
+++ b/tools/validate_configs.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Local validator for instrument profiles and override bundles.
+Requires: pip install jsonschema pyyaml
+"""
+
+import json
+import pathlib
+import sys
+
+import yaml
+from jsonschema import Draft7Validator, validate
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SCH_INST = ROOT / "configs/symbolic/instruments/instrument.schema.yaml"
+SCH_OVR = ROOT / "configs/symbolic/overrides/_schemas/instrument_override.schema.json"
+
+
+def load_yaml(p):
+    return yaml.safe_load(pathlib.Path(p).read_text())
+
+
+def load_json(p):
+    return json.loads(pathlib.Path(p).read_text())
+
+
+def check_schema(schema_path, doc_path):
+    schema = (
+        load_yaml(schema_path)
+        if schema_path.suffix in (".yaml", ".yml")
+        else load_json(schema_path)
+    )
+    Draft7Validator.check_schema(schema)
+    doc = load_yaml(doc_path) if doc_path.suffix in (".yaml", ".yml") else load_json(doc_path)
+    validate(instance=doc, schema=schema)
+    print(f"OK: {doc_path}")
+
+
+def main():
+    # Instrument profiles
+    profs = [
+        ROOT / "configs/symbolic/instruments/ariel/airs.yaml",
+        ROOT / "configs/symbolic/instruments/ariel/fgs.yaml",
+        ROOT / "configs/symbolic/instruments/jwst/nirspec.yaml",
+        ROOT / "configs/symbolic/instruments/simulated/ideal.yaml",
+    ]
+    # Override bundles
+    ovrs = [
+        ROOT / "configs/symbolic/overrides/instruments/dev-ariel.yaml",
+        ROOT / "configs/symbolic/overrides/instruments/jwst-benchmark.yaml",
+        ROOT / "configs/symbolic/overrides/instruments/fast-sim.yaml",
+        ROOT / "configs/symbolic/overrides/instruments/jitter-stress.yaml",
+        ROOT / "configs/symbolic/overrides/instruments/thermal-drift.yaml",
+        ROOT / "configs/symbolic/overrides/instruments/recovery-safe.yaml",
+        ROOT / "configs/symbolic/overrides/instruments/qa-battery.yaml",
+        ROOT / "configs/symbolic/overrides/instruments/fgs-guiding.yaml",
+    ]
+    try:
+        for p in profs:
+            check_schema(SCH_INST, p)
+        for o in ovrs:
+            check_schema(SCH_OVR, o)
+        print("All validations passed.")
+    except Exception as e:
+        print(f"Validation failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add instrument profile schema and canonical instrument configs
- provide override bundles with JSON schema validation
- include validator script, Makefile target, and CI workflow

## Testing
- `pre-commit run --files .github/workflows/validate-symbolic-configs.yml Makefile configs/symbolic/README.md configs/symbolic/index.yaml configs/symbolic/instruments/README.md configs/symbolic/instruments/instrument.schema.yaml configs/symbolic/instruments/ariel/airs.yaml configs/symbolic/instruments/ariel/fgs.yaml configs/symbolic/instruments/jwst/nirspec.yaml configs/symbolic/instruments/simulated/ideal.yaml configs/symbolic/overrides/_schemas/instrument_override.schema.json configs/symbolic/overrides/instruments/README.md configs/symbolic/overrides/instruments/dev-ariel.yaml configs/symbolic/overrides/instruments/fast-sim.yaml configs/symbolic/overrides/instruments/fgs-guiding.yaml configs/symbolic/overrides/instruments/jitter-stress.yaml configs/symbolic/overrides/instruments/jwst-benchmark.yaml configs/symbolic/overrides/instruments/qa-battery.yaml configs/symbolic/overrides/instruments/recovery-safe.yaml configs/symbolic/overrides/instruments/thermal-drift.yaml tools/validate_configs.py`
- `make validate-instruments`
- `PYTHONPATH=. pytest -q` *(fails: FGS1 latent D mismatch: expected 256, got 32)*

------
https://chatgpt.com/codex/tasks/task_e_689e5909dae4832a866cbac7f00eef04