### PR TITLE
feat: introduce hydra profile system with logging and tracking toggles

### DIFF
--- a/.github/workflows/config-smoke.yml
+++ b/.github/workflows/config-smoke.yml
@@ -1,0 +1,13 @@
+name: config-smoke
+on: [push, pull_request]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: List configs
+        run: |
+          ls -R configs
+      - name: Verify symlink
+        run: |
+          test -L configs/profiles/active.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Thumbs.db
 
 # Docker
 *.bak
+var/

--- a/bin/profile
+++ b/bin/profile
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ $# -ne 1 ]]; then
+  echo "usage: bin/profile <local-dev|hpc-slurm|cloud-aws|cloud-gcp|ci|viz-hi-mem|ariel-2025>" >&2
+  exit 2
+fi
+name="$1"
+src="configs/symbolic/overrides/profiles/${name}.yaml"
+dst="configs/profiles/active.yaml"
+[[ -f "$src" ]] || { echo "unknown profile: $name" >&2; exit 3; }
+ln -snf "../symbolic/overrides/profiles/${name}.yaml" "$dst"
+
+# gather context
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+git_hash="$(git rev-parse --short HEAD 2>/dev/null || echo 'NA')"
+env_short="$(env | egrep '^(ARIEL_|SMV50_|MLFLOW_|WANDB_|S3_|GCS_)' | sort | tr -d '\n' | sed 's/"/\\"/g')"
+
+# write JSONL event
+mkdir -p var/events
+printf '{"ts":"%s","event":"profile_switch","profile":"%s","git":"%s","env":"%s"}\n' \
+  "$ts" "$name" "$git_hash" "$env_short" >> var/events/events.jsonl
+
+# friendly git commit (optional)
+if git rev-parse --git-dir >/dev/null 2>&1; then
+  git add configs/profiles/active.yaml var/events/events.jsonl
+  git commit -m "chore(config): switch active profile -> ${name}"
+fi
+
+echo "active profile -> ${name}"

--- a/configs/hydra/main.yaml
+++ b/configs/hydra/main.yaml
@@ -1,0 +1,25 @@
+# hydra entry config: wires groups + symbolic active profile
+defaults:
+  - profiles: active
+  - paths: default
+  - logging: default
+  - tracking: off
+  - scheduler: none
+  - runtime: defaults
+  - _self_
+
+# universal knobs available to any module
+seed: 42
+run:
+  name: ${now:%Y%m%d_%H%M%S}_${profiles.name}
+  mode: ${profiles.mode}   # dev|prod|ci|hpc|cloud
+  profile: ${profiles.name}
+  # hydra runtime
+  workdir: ${paths.run_dir}/${run.name}
+  outputs: ${paths.outputs_dir}/${run.name}
+
+# attach logging choices
+logging:
+  console_level: INFO
+  file_level: INFO
+  jsonl_level: INFO

--- a/configs/logging/default.yaml
+++ b/configs/logging/default.yaml
@@ -1,0 +1,12 @@
+console:
+  level: ${logging.console_level}
+files:
+  rotate_mb: ${profiles.logging.file_rotate_mb,50}
+  keep: ${profiles.logging.file_keep,10}
+  dir: var/logs
+jsonl:
+  level: ${logging.jsonl_level}
+  path: var/events/events.jsonl
+format:
+  human: "[%(asctime)s] %(levelname)s %(name)s: %(message)s"
+  jsonl_keys: [ts, level, name, msg, run, git, profile, env]

--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -1,0 +1,5 @@
+# paths resolved per profile unless explicitly overridden
+run_dir: ${paths.artifacts_root}/runs
+outputs_dir: ${paths.artifacts_root}/outputs
+# passthroughs that profiles should define:
+# data_root, cache_root, artifacts_root

--- a/configs/profiles/active.yaml
+++ b/configs/profiles/active.yaml
@@ -1,0 +1,1 @@
+../symbolic/overrides/profiles/local-dev.yaml

--- a/configs/runtime/defaults.yaml
+++ b/configs/runtime/defaults.yaml
@@ -1,0 +1,2 @@
+num_workers: ${profiles.runtime.num_workers,4}
+device: ${profiles.runtime.device,cuda_if_available}

--- a/configs/scheduler/none.yaml
+++ b/configs/scheduler/none.yaml
@@ -1,0 +1,1 @@
+type: none

--- a/configs/scheduler/slurm.yaml
+++ b/configs/scheduler/slurm.yaml
@@ -1,0 +1,6 @@
+type: slurm
+account: ${profiles.scheduler.account,default}
+qos: ${profiles.scheduler.qos,normal}
+partition: ${profiles.scheduler.partition,gpu}
+gpus_per_task: ${profiles.scheduler.gpus_per_task,1}
+time: ${profiles.scheduler.time,08:00:00}

--- a/configs/symbolic/overrides/profiles/ariel-2025.yaml
+++ b/configs/symbolic/overrides/profiles/ariel-2025.yaml
@@ -1,0 +1,26 @@
+name: ariel-2025
+mode: prod
+desc: NeurIPS Ariel Data Challenge 2025 pipeline defaults
+paths:
+  data_root: ${oc.env:ARIEL_DATA,${hydra:runtime.cwd}/data/ariel}
+  cache_root: ${oc.env:ARIEL_CACHE,${hydra:runtime.cwd}/.cache/ariel}
+  artifacts_root: ${oc.env:ARIEL_ARTIFACTS,${hydra:runtime.cwd}/artifacts/ariel}
+  spectra_catalog: ${paths.data_root}/catalogs
+  outputs_dir: ${hydra:runtime.cwd}/outputs
+logging:
+  console_level: INFO
+  file_rotate_mb: 100
+  file_keep: 30
+  jsonl_level: INFO
+tracking:
+  mlflow:
+    enabled: true
+    uri: ${oc.env:MLFLOW_TRACKING_URI,sqlite:///mlruns.db}
+    exp: ariel-2025
+  wandb:
+    enabled: false
+scheduler:
+  type: none
+runtime:
+  num_workers: ${oc.env:SMV50_NUM_WORKERS,8}
+  device: cuda_if_available

--- a/configs/symbolic/overrides/profiles/ci.yaml
+++ b/configs/symbolic/overrides/profiles/ci.yaml
@@ -1,0 +1,19 @@
+name: ci
+mode: ci
+desc: CI runners — strict determinism, reduced logs
+paths:
+  data_root: ${hydra:runtime.cwd}/.ci/data
+  cache_root: ${hydra:runtime.cwd}/.ci/cache
+  artifacts_root: ${hydra:runtime.cwd}/.ci/artifacts
+logging:
+  console_level: WARNING
+  file_rotate_mb: 10
+  file_keep: 3
+tracking:
+  mlflow: {enabled: false}
+  wandb: {enabled: false}
+scheduler:
+  type: none
+runtime:
+  num_workers: 2
+  device: cpu

--- a/configs/symbolic/overrides/profiles/cloud-aws.yaml
+++ b/configs/symbolic/overrides/profiles/cloud-aws.yaml
@@ -1,0 +1,25 @@
+name: cloud-aws
+mode: cloud
+desc: AWS batch/EC2 + S3 artifact store
+paths:
+  data_root: s3://${oc.env:S3_DATA_BUCKET,ariel-data}/
+  cache_root: /mnt/cache
+  artifacts_root: s3://${oc.env:S3_ARTIFACTS_BUCKET,ariel-artifacts}/
+logging:
+  console_level: INFO
+  file_rotate_mb: 50
+  file_keep: 10
+tracking:
+  mlflow:
+    enabled: true
+    uri: ${oc.env:MLFLOW_TRACKING_URI,https://mlflow.your.domain}
+    exp: ariel-cloud
+  wandb:
+    enabled: true
+    entity: ${oc.env:WANDB_ENTITY,ariel}
+    project: ${oc.env:WANDB_PROJECT,spectramind}
+scheduler:
+  type: none
+runtime:
+  num_workers: ${oc.env:SMV50_NUM_WORKERS,12}
+  device: cuda_if_available

--- a/configs/symbolic/overrides/profiles/cloud-gcp.yaml
+++ b/configs/symbolic/overrides/profiles/cloud-gcp.yaml
@@ -1,0 +1,25 @@
+name: cloud-gcp
+mode: cloud
+desc: GCP + GCS buckets, TPU/GPU optional
+paths:
+  data_root: gs://${oc.env:GCS_DATA_BUCKET,ariel-data}/
+  cache_root: /mnt/cache
+  artifacts_root: gs://${oc.env:GCS_ARTIFACTS_BUCKET,ariel-artifacts}/
+logging:
+  console_level: INFO
+  file_rotate_mb: 50
+  file_keep: 10
+tracking:
+  mlflow:
+    enabled: true
+    uri: ${oc.env:MLFLOW_TRACKING_URI,https://mlflow.your.domain}
+    exp: ariel-cloud
+  wandb:
+    enabled: true
+    entity: ${oc.env:WANDB_ENTITY,ariel}
+    project: ${oc.env:WANDB_PROJECT,spectramind}
+scheduler:
+  type: none
+runtime:
+  num_workers: ${oc.env:SMV50_NUM_WORKERS,12}
+  device: cuda_if_available

--- a/configs/symbolic/overrides/profiles/hpc-slurm.yaml
+++ b/configs/symbolic/overrides/profiles/hpc-slurm.yaml
@@ -1,0 +1,28 @@
+name: hpc-slurm
+mode: hpc
+desc: SLURM cluster, checkpointing, minimized console
+paths:
+  data_root: /fsx/data
+  cache_root: /fsx/cache
+  artifacts_root: /fsx/artifacts
+logging:
+  console_level: INFO
+  file_rotate_mb: 100
+  file_keep: 20
+tracking:
+  mlflow:
+    enabled: true
+    uri: ${oc.env:MLFLOW_TRACKING_URI,sqlite:///mlruns.db}
+    exp: ${oc.env:MLFLOW_EXPERIMENT,ariel}
+  wandb:
+    enabled: false
+scheduler:
+  type: slurm
+  account: ${oc.env:SLURM_ACCOUNT,default}
+  qos: ${oc.env:SLURM_QOS,normal}
+  partition: ${oc.env:SLURM_PARTITION,gpu}
+  gpus_per_task: 1
+  time: "8:00:00"
+runtime:
+  num_workers: ${oc.env:SMV50_NUM_WORKERS,16}
+  device: cuda

--- a/configs/symbolic/overrides/profiles/local-dev.yaml
+++ b/configs/symbolic/overrides/profiles/local-dev.yaml
@@ -1,0 +1,21 @@
+name: local-dev
+mode: dev
+desc: Local workstation, fast iteration, rich logs
+paths:
+  data_root: ${oc.env:DATA_ROOT,${hydra:runtime.cwd}/data}
+  cache_root: ${oc.env:CACHE_ROOT,${hydra:runtime.cwd}/.cache}
+  artifacts_root: ${oc.env:ARTIFACTS_ROOT,${hydra:runtime.cwd}/artifacts}
+logging:
+  console_level: DEBUG
+  file_rotate_mb: 20
+  file_keep: 5
+tracking:
+  mlflow:
+    enabled: false
+  wandb:
+    enabled: false
+scheduler:
+  type: none
+runtime:
+  num_workers: ${oc.env:SMV50_NUM_WORKERS,8}
+  device: ${oc.env:SMV50_DEVICE,cuda_if_available}

--- a/configs/symbolic/overrides/profiles/viz-hi-mem.yaml
+++ b/configs/symbolic/overrides/profiles/viz-hi-mem.yaml
@@ -1,0 +1,19 @@
+name: viz-hi-mem
+mode: prod
+desc: Visualization/EDA nodes with large RAM
+paths:
+  data_root: ${oc.env:DATA_ROOT,${hydra:runtime.cwd}/data}
+  cache_root: ${oc.env:CACHE_ROOT,${hydra:runtime.cwd}/.cache}
+  artifacts_root: ${oc.env:ARTIFACTS_ROOT,${hydra:runtime.cwd}/artifacts}
+logging:
+  console_level: INFO
+  file_rotate_mb: 50
+  file_keep: 10
+tracking:
+  mlflow: {enabled: false}
+  wandb: {enabled: false}
+scheduler:
+  type: none
+runtime:
+  num_workers: ${oc.env:SMV50_NUM_WORKERS,4}
+  device: cpu

--- a/configs/tracking/mlflow.yaml
+++ b/configs/tracking/mlflow.yaml
@@ -1,0 +1,6 @@
+mlflow:
+  enabled: ${profiles.tracking.mlflow.enabled,true}
+  uri: ${profiles.tracking.mlflow.uri,sqlite:///mlruns.db}
+  exp: ${profiles.tracking.mlflow.exp,default}
+wandb:
+  enabled: false

--- a/configs/tracking/off.yaml
+++ b/configs/tracking/off.yaml
@@ -1,0 +1,2 @@
+mlflow: {enabled: false}
+wandb:  {enabled: false}

--- a/configs/tracking/wandb.yaml
+++ b/configs/tracking/wandb.yaml
@@ -1,0 +1,5 @@
+mlflow: {enabled: false}
+wandb:
+  enabled: ${profiles.tracking.wandb.enabled,true}
+  entity: ${profiles.tracking.wandb.entity,ariel}
+  project: ${profiles.tracking.wandb.project,spectramind}

--- a/examples/logging_bootstrap.py
+++ b/examples/logging_bootstrap.py
@@ -1,0 +1,77 @@
+import json
+import logging
+import logging.handlers
+import os
+import subprocess
+import time
+from pathlib import Path
+
+
+def git_hash():
+    try:
+        return (
+            subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.DEVNULL
+            )
+            .decode()
+            .strip()
+        )
+    except Exception:
+        return "NA"
+
+
+def init_logging(  # noqa: PLR0913
+    console_level="INFO",
+    file_dir="var/logs",
+    rotate_mb=50,
+    keep=10,
+    jsonl_path="var/events/events.jsonl",
+    run="NA",
+    profile="NA",
+):
+    Path(file_dir).mkdir(parents=True, exist_ok=True)
+    Path(jsonl_path).parent.mkdir(parents=True, exist_ok=True)
+
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+
+    ch = logging.StreamHandler()
+    ch.setLevel(getattr(logging, console_level))
+    ch.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(ch)
+
+    fh = logging.handlers.RotatingFileHandler(
+        filename=str(Path(file_dir) / "app.log"), maxBytes=rotate_mb * 1024 * 1024, backupCount=keep
+    )
+    fh.setLevel(logging.INFO)
+    fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(fh)
+
+    class Jsonl(logging.Handler):
+        def __init__(self, path):
+            super().__init__(logging.INFO)
+            self.path = path
+
+        def emit(self, record):
+            d = {
+                "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "level": record.levelname,
+                "name": record.name,
+                "msg": record.getMessage(),
+                "run": run,
+                "git": git_hash(),
+                "profile": profile,
+            }
+            with open(self.path, "a") as f:
+                f.write(json.dumps(d) + "\n")
+
+    jh = Jsonl(jsonl_path)
+    logger.addHandler(jh)
+    return logger
+
+
+if __name__ == "__main__":
+    log = init_logging(
+        run=os.getenv("SMV50_RUN", "ad-hoc"), profile=os.getenv("SMV50_PROFILE", "unknown")
+    )
+    log.info("jsonl + rotating file logging online.")


### PR DESCRIPTION
## Summary
- add Hydra main config that wires in symbolic profiles and shared groups
- provide production-ready profiles for local-dev, HPC, cloud, CI, visualization and Ariel 2025
- include profile switcher script, logging bootstrap example, and config smoke GitHub workflow

## Testing
- `pre-commit run --files $(git diff --name-only --staged)`
- `python examples/logging_bootstrap.py`

------
https://chatgpt.com/codex/tasks/task_e_689e62c0ec30832a8bfc155920cb2359