### PR TITLE
feat(symbolic): add Hydra-safe profile overrides and schemas

### DIFF
--- a/configs/symbolic/overrides/_schemas/profile.schema.yaml
+++ b/configs/symbolic/overrides/_schemas/profile.schema.yaml
@@ -1,0 +1,90 @@
+# JSON-Schema style validator for *.profile.yaml
+
+$schema: "http://json-schema.org/draft-07/schema#"
+title: "Symbolic Profile Schema"
+type: object
+properties:
+  symbolic:
+    type: object
+    required: ["loss","sigma","guards","reporting"]
+    properties:
+      loss:
+        type: object
+        properties:
+          weights:
+            type: object
+            properties:
+              smooth_l2_mu: { type: number, minimum: 0.0 }
+              nonneg_mu:    { type: number, minimum: 0.0 }
+              fft_band_limit: { type: number, minimum: 0.0, maximum: 1.0 }
+              asymmetry_mu: { type: number, minimum: 0.0 }
+              photonic_alignment: { type: number, minimum: 0.0 }
+              molecule_region_coherence: { type: number, minimum: 0.0 }
+              symbol_coverage_penalty: { type: number, minimum: 0.0 }
+            additionalProperties: false
+          options:
+            type: object
+            properties:
+              fft:
+                type: object
+                properties:
+                  window: { type: string }
+                  max_rel_band: { type: number, minimum: 0.0, maximum: 1.0 }
+                required: ["window","max_rel_band"]
+                additionalProperties: true
+              molecule_sets:
+                type: object
+                properties:
+                  include:
+                    type: array
+                    items: { type: string }
+                required: ["include"]
+                additionalProperties: false
+              photonic:
+                type: object
+                properties:
+                  use_fgs1_phase_anchor: { type: boolean }
+                  jitter_robust: { type: boolean }
+                required: ["use_fgs1_phase_anchor","jitter_robust"]
+                additionalProperties: false
+            additionalProperties: true
+        required: ["weights","options"]
+        additionalProperties: false
+      sigma:
+        type: object
+        properties:
+          calibration:
+            type: object
+            properties:
+              temperature_scaling: { type: number, minimum: 0.0 }
+              corel_weight: { type: number, minimum: 0.0 }
+              conformal_coverage_target: { type: number, minimum: 0.0, maximum: 1.0 }
+              per_bin: { type: boolean }
+            required: ["temperature_scaling","corel_weight","conformal_coverage_target","per_bin"]
+            additionalProperties: false
+        required: ["calibration"]
+        additionalProperties: false
+      guards:
+        type: object
+        properties:
+          ood:
+            type: object
+            properties:
+              enable_entropy_tripwire: { type: boolean }
+              entropy_threshold: { type: number }
+              zscore_threshold: { type: number }
+              switch_to_profile: { type: string }
+            required: ["enable_entropy_tripwire","entropy_threshold","zscore_threshold","switch_to_profile"]
+            additionalProperties: false
+        required: ["ood"]
+        additionalProperties: false
+      reporting:
+        type: object
+        properties:
+          export_masks: { type: boolean }
+          export_rule_scores: { type: boolean }
+        required: ["export_masks","export_rule_scores"]
+        additionalProperties: false
+    additionalProperties: false
+required: ["symbolic"]
+additionalProperties: false

--- a/configs/symbolic/overrides/_schemas/profile_map.schema.yaml
+++ b/configs/symbolic/overrides/_schemas/profile_map.schema.yaml
@@ -1,0 +1,46 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: "Symbolic Profile Selector Schema"
+type: object
+properties:
+  symbolic:
+    type: object
+    properties:
+      profiles:
+        type: object
+        properties:
+          selector:
+            type: object
+            properties:
+              rules:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    name: { type: string }
+                    when:
+                      type: object
+                      properties:
+                        all:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              key: { type: string }
+                              op:  { type: string }
+                              value: {}
+                            required: ["key","op"]
+                            additionalProperties: false
+                      required: ["all"]
+                      additionalProperties: false
+                    use: { type: string }
+                  required: ["name","when","use"]
+                  additionalProperties: false
+              default: { type: string }
+            required: ["rules","default"]
+            additionalProperties: false
+        required: ["selector"]
+        additionalProperties: false
+    required: ["profiles"]
+    additionalProperties: false
+required: ["symbolic"]
+additionalProperties: false

--- a/configs/symbolic/overrides/competition/profiles.yaml
+++ b/configs/symbolic/overrides/competition/profiles.yaml
@@ -1,32 +1,11 @@
-# configs/symbolic/overrides/competition/profiles.yaml
+# Competition-mode pinning and audit trail for symbolic profiles
 
-# Symbolic profile catalog for molecule bands / detector regions / priors.
-
-symbolic:
-  profiles:
-    default:
-      description: "Baseline symbolic profile for most targets"
-      molecules: ["H2O", "CO2", "CH4", "CO"]
-      detector_regions:
-        - name: "AIRS_low"
-          bins: [0, 140]
-        - name: "AIRS_mid"
-          bins: [140, 220]
-        - name: "AIRS_high"
-          bins: [220, 283]
-      priors:
-        scale_height_snr_weight: 1.0
-        limb_darkening_weight: 0.3
-        ood_guard_weight: 0.2
-    methane_rich:
-      description: "Assumes stronger CH4 absorption likelihood"
-      molecules: ["H2O", "CO2", "CH4", "CO"]
-      priors:
-        methane_band_boost: 1.3
-        co2_band_penalty: 0.9
-    hazy:
-      description: "Haze continuum likely; smoothness emphasized"
-      molecules: ["H2O", "CO2", "CH4", "CO"]
-      priors:
-        smoothness_emphasis: 1.4
-        highfreq_suppression: 1.2
+competition:
+  leaderboard_mode: true
+  symbolic:
+    profiles:
+      pinned: "hot_jupiter"         # pin in leaderboard runs (override index.yaml)
+      allow_auto: false
+      audit:
+        write_manifest: true
+        manifest_path: "artifacts/competition_profile_manifest.json"

--- a/configs/symbolic/overrides/events/profile_switch.rules.yaml
+++ b/configs/symbolic/overrides/events/profile_switch.rules.yaml
@@ -1,0 +1,22 @@
+# Event-driven profile switching rules (consumed by the guardrails/diagnostics CLI).
+
+events:
+  profile_switch:
+    enabled: true
+    rules:
+      - name: "High-entropy detection"
+        when:
+          any:
+            - { key: "diagnostics.entropy", op: ">", value: 1.5 }
+            - { key: "diagnostics.zscore_max", op: ">", value: 3.5 }
+        action:
+          set_profile: "ood_guardrails"
+      - name: "AIRS low-SNR fallback"
+        when:
+          all:
+            - { key: "instrument", op: "==", value: "AIRS" }
+            - { key: "airs_snr", op: "<", value: 4.0 }
+        action:
+          set_profile: "ood_guardrails"
+    on_no_match:
+      keep: true

--- a/configs/symbolic/overrides/instruments/link_profiles.yaml
+++ b/configs/symbolic/overrides/instruments/link_profiles.yaml
@@ -1,0 +1,6 @@
+# Lightweight bridge so instrument overrides can consume the current symbolic profile key.
+
+symbolic:
+  profiles:
+    # At runtime, Hydra will resolve this to the active profile key from profiles/index.yaml or auto selector.
+    current_ref: "${symbolic.profiles.active}"

--- a/configs/symbolic/overrides/profiles/README.md
+++ b/configs/symbolic/overrides/profiles/README.md
@@ -1,0 +1,21 @@
+# Symbolic Profiles (Overrides)
+
+Mission: Provide declarative, Hydra-safe symbolic profile overlays that select physically grounded rule packs and weights per planet/instrument context, and can be switched dynamically (by metadata, events, or CLI).
+
+## Why profiles?
+- Different planet classes (UHJ, HJ, Warm Neptune, Temperate Super-Earth) exhibit distinct spectral fingerprints and systematics; profiles tune symbolic constraints (smoothness, nonnegativity, molecule-region priors, FFT windows, photonic alignment, quantile/σ calibration weights) accordingly.
+- Profiles also gate calibration & decoder knobs for instrument-specific behavior (FGS1 vs. AIRS), while remaining compliant with reproducibility and CI schema validation.
+
+## Loading order
+1. `index.yaml` declares the active profile and lists available profiles.
+2. `profile_map.yaml` contains rule-based selectors that can auto-switch the profile based on metadata (e.g., T_eq, log g).
+3. `*.profile.yaml` files define self-contained overlays merged by Hydra into the runtime config tree.
+
+## Validation
+- JSON Schema-ish documents live in `../_schemas/`. CI/selftest validates structure (required keys/ranges).
+- Keep comments; they’re stripped by loaders before validation if needed.
+
+## Integration
+- `../instruments/link_profiles.yaml` lets instrument overrides reference the active profile class for consistent weights.
+- `../events/profile_switch.rules.yaml` offers declarative event-driven switches (e.g., "if OOD_snr_drop > τ → use ood_guardrails").
+- `../competition/profiles.yaml` can pin profiles in "leaderboard mode".

--- a/configs/symbolic/overrides/profiles/default.profile.yaml
+++ b/configs/symbolic/overrides/profiles/default.profile.yaml
@@ -1,0 +1,36 @@
+# Baseline symbolic profile: conservative, physics-informed priors for general use.
+
+symbolic:
+  loss:
+    weights:
+      smooth_l2_mu: 1.0              # spectral smoothness on μ
+      nonneg_mu: 0.5                 # weak nonnegativity unless negative depths are permitted by task
+      fft_band_limit: 0.25           # penalize implausible high-frequency oscillations
+      asymmetry_mu: 0.2              # regularize odd-even bin asymmetry
+      photonic_alignment: 0.6        # align AIRS features with FGS1 transit phase morphology
+      molecule_region_coherence: 0.8 # stabilize known bands (H2O, CO2, CH4, CO, NH3)
+      symbol_coverage_penalty: 0.1   # soft encourage broad coverage, reduce spiky fits
+    options:
+      fft:
+        window: "hann"
+        max_rel_band: 0.35
+      molecule_sets:
+        include: ["H2O","CO2","CH4","CO","NH3"]  # core set; VO/TiO off by default here
+      photonic:
+        use_fgs1_phase_anchor: true
+        jitter_robust: true
+  sigma:
+    calibration:
+      temperature_scaling: 1.0
+      corel_weight: 0.5
+      conformal_coverage_target: 0.68
+      per_bin: true
+  guards:
+    ood:
+      enable_entropy_tripwire: true
+      entropy_threshold: 1.25
+      zscore_threshold: 3.0
+      switch_to_profile: "ood_guardrails"
+  reporting:
+    export_masks: true
+    export_rule_scores: true

--- a/configs/symbolic/overrides/profiles/hot_jupiter.profile.yaml
+++ b/configs/symbolic/overrides/profiles/hot_jupiter.profile.yaml
@@ -1,0 +1,36 @@
+# Hot Jupiter symbolic profile: emphasize strong molecular bands, stabilize systematics at high T_eq.
+
+symbolic:
+  loss:
+    weights:
+      smooth_l2_mu: 0.8
+      nonneg_mu: 0.4
+      fft_band_limit: 0.2
+      asymmetry_mu: 0.15
+      photonic_alignment: 0.8
+      molecule_region_coherence: 1.2
+      symbol_coverage_penalty: 0.05
+    options:
+      fft:
+        window: "hann"
+        max_rel_band: 0.30
+      molecule_sets:
+        include: ["H2O","CO2","CH4","CO","NH3","HCN","C2H2"]
+      photonic:
+        use_fgs1_phase_anchor: true
+        jitter_robust: true
+  sigma:
+    calibration:
+      temperature_scaling: 0.9
+      corel_weight: 0.7
+      conformal_coverage_target: 0.75
+      per_bin: true
+  guards:
+    ood:
+      enable_entropy_tripwire: true
+      entropy_threshold: 1.10
+      zscore_threshold: 2.8
+      switch_to_profile: "ood_guardrails"
+  reporting:
+    export_masks: true
+    export_rule_scores: true

--- a/configs/symbolic/overrides/profiles/index.yaml
+++ b/configs/symbolic/overrides/profiles/index.yaml
@@ -1,0 +1,24 @@
+# Hydra-safe index of symbolic profiles and the currently active selection.
+#
+# Switch at runtime with: +symbolic.profiles.active=warm_neptune
+
+symbolic:
+  profiles:
+    active: "default"             # active profile key (must exist in available)
+    available:
+      - "default"
+      - "hot_jupiter"
+      - "ultra_hot_jupiter"
+      - "warm_neptune"
+      - "temperate_super_earth"
+      - "ood_guardrails"
+    files:
+      default: "default.profile.yaml"
+      hot_jupiter: "hot_jupiter.profile.yaml"
+      ultra_hot_jupiter: "ultra_hot_jupiter.profile.yaml"
+      warm_neptune: "warm_neptune.profile.yaml"
+      temperate_super_earth: "temperate_super_earth.profile.yaml"
+      ood_guardrails: "ood_guardrails.profile.yaml"
+    auto:
+      enabled: true               # enable profile auto-selection via profile_map.yaml
+      fallback: "default"         # fallback if no rule matches

--- a/configs/symbolic/overrides/profiles/ood_guardrails.profile.yaml
+++ b/configs/symbolic/overrides/profiles/ood_guardrails.profile.yaml
@@ -1,0 +1,36 @@
+# OOD Guardrails: highly conservative constraints to prevent overconfident hallucinations on out-of-distribution inputs.
+
+symbolic:
+  loss:
+    weights:
+      smooth_l2_mu: 2.0
+      nonneg_mu: 1.2
+      fft_band_limit: 0.22
+      asymmetry_mu: 0.25
+      photonic_alignment: 0.9
+      molecule_region_coherence: 0.6     # relax molecule push; avoid forcing features
+      symbol_coverage_penalty: 0.2
+    options:
+      fft:
+        window: "hann"
+        max_rel_band: 0.25
+      molecule_sets:
+        include: ["H2O","CO2"]           # strict minimal set unless evidence grows
+      photonic:
+        use_fgs1_phase_anchor: true
+        jitter_robust: true
+  sigma:
+    calibration:
+      temperature_scaling: 1.25
+      corel_weight: 0.9
+      conformal_coverage_target: 0.90
+      per_bin: true
+  guards:
+    ood:
+      enable_entropy_tripwire: true
+      entropy_threshold: 0.0            # already in guardrails; keep on
+      zscore_threshold: 0.0
+      switch_to_profile: "ood_guardrails"
+  reporting:
+    export_masks: true
+    export_rule_scores: true

--- a/configs/symbolic/overrides/profiles/profile_map.yaml
+++ b/configs/symbolic/overrides/profiles/profile_map.yaml
@@ -1,0 +1,52 @@
+# Auto-selection map for symbolic profiles based on planet metadata/instrument context.
+#
+# Evaluated in order; first match wins. Uses simple comparator ops on metadata keys as emitted by pipeline.
+#
+# Supported ops: ==, !=, <=, <, >=, >, in (lists), between (inclusive), regex (for IDs), exists
+#
+# Keys reference canonical metadata: T_eq[K], logg[cgs], R_p[R_earth], M_p[M_earth], star_teff[K], star_fe_h, period[d],
+# instrument ("FGS1"|"AIRS"), and submission_mode ("leaderboard"|"diagnostics").
+#
+# Example CLI to print resolved profile:
+# python -m spectramind diagnose profile --print-active --meta path/to/meta.json
+
+symbolic:
+  profiles:
+    selector:
+      rules:
+        - name: "Ultra-Hot Jupiter (UHJ)"
+          when:
+            all:
+              - { key: "T_eq", op: ">=", value: 2000 }
+              - { key: "R_p", op: ">=", value: 9.0 }       # ~R_Jupiter ~ 11.2 R_earth; this is a soft lower bound
+          use: "ultra_hot_jupiter"
+        - name: "Hot Jupiter (HJ)"
+          when:
+            all:
+              - { key: "T_eq", op: "between", value: [1200, 2000] }
+              - { key: "R_p", op: ">=", value: 7.0 }
+          use: "hot_jupiter"
+        - name: "Warm Neptune"
+          when:
+            all:
+              - { key: "T_eq", op: "between", value: [600, 1200] }
+              - { key: "R_p", op: "between", value: [3.0, 6.0] }
+          use: "warm_neptune"
+        - name: "Temperate Super-Earth"
+          when:
+            all:
+              - { key: "T_eq", op: "between", value: [300, 700] }
+              - { key: "R_p", op: "between", value: [1.2, 2.5] }
+          use: "temperate_super_earth"
+        - name: "Instrument-specific tightening on AIRS if SNR low"
+          when:
+            all:
+              - { key: "instrument", op: "==", value: "AIRS" }
+              - { key: "airs_snr", op: "<", value: 4.0 }
+          use: "ood_guardrails"
+        - name: "Competition pin (leaderboard mode)"
+          when:
+            all:
+              - { key: "submission_mode", op: "==", value: "leaderboard" }
+          use: "hot_jupiter"
+      default: "default"

--- a/configs/symbolic/overrides/profiles/temperate_super_earth.profile.yaml
+++ b/configs/symbolic/overrides/profiles/temperate_super_earth.profile.yaml
@@ -1,0 +1,36 @@
+# Temperate Super-Earth profile: conservative molecule priors, higher smoothness, robust σ calibration.
+
+symbolic:
+  loss:
+    weights:
+      smooth_l2_mu: 1.6
+      nonneg_mu: 0.7
+      fft_band_limit: 0.30
+      asymmetry_mu: 0.2
+      photonic_alignment: 0.65
+      molecule_region_coherence: 0.9
+      symbol_coverage_penalty: 0.10
+    options:
+      fft:
+        window: "hann"
+        max_rel_band: 0.35
+      molecule_sets:
+        include: ["H2O","CO2","CH4"]  # cautious set; expand only with evidence
+      photonic:
+        use_fgs1_phase_anchor: true
+        jitter_robust: true
+  sigma:
+    calibration:
+      temperature_scaling: 1.1
+      corel_weight: 0.5
+      conformal_coverage_target: 0.68
+      per_bin: true
+  guards:
+    ood:
+      enable_entropy_tripwire: true
+      entropy_threshold: 1.30
+      zscore_threshold: 3.2
+      switch_to_profile: "ood_guardrails"
+  reporting:
+    export_masks: true
+    export_rule_scores: true

--- a/configs/symbolic/overrides/profiles/ultra_hot_jupiter.profile.yaml
+++ b/configs/symbolic/overrides/profiles/ultra_hot_jupiter.profile.yaml
@@ -1,0 +1,36 @@
+# Ultra-Hot Jupiter profile: supports ion/metal signatures and broader windows; stronger σ-calibration.
+
+symbolic:
+  loss:
+    weights:
+      smooth_l2_mu: 0.7
+      nonneg_mu: 0.3
+      fft_band_limit: 0.18
+      asymmetry_mu: 0.12
+      photonic_alignment: 0.9
+      molecule_region_coherence: 1.4
+      symbol_coverage_penalty: 0.03
+    options:
+      fft:
+        window: "hann"
+        max_rel_band: 0.28
+      molecule_sets:
+        include: ["H2O","CO","CO2","TiO","VO","FeH","SiO"]
+      photonic:
+        use_fgs1_phase_anchor: true
+        jitter_robust: true
+  sigma:
+    calibration:
+      temperature_scaling: 0.85
+      corel_weight: 0.8
+      conformal_coverage_target: 0.80
+      per_bin: true
+  guards:
+    ood:
+      enable_entropy_tripwire: true
+      entropy_threshold: 1.05
+      zscore_threshold: 2.5
+      switch_to_profile: "ood_guardrails"
+  reporting:
+    export_masks: true
+    export_rule_scores: true

--- a/configs/symbolic/overrides/profiles/warm_neptune.profile.yaml
+++ b/configs/symbolic/overrides/profiles/warm_neptune.profile.yaml
@@ -1,0 +1,36 @@
+# Warm Neptune profile: moderate bands, stronger smoothness to fight low SNR and feature crowding.
+
+symbolic:
+  loss:
+    weights:
+      smooth_l2_mu: 1.3
+      nonneg_mu: 0.6
+      fft_band_limit: 0.27
+      asymmetry_mu: 0.18
+      photonic_alignment: 0.7
+      molecule_region_coherence: 1.0
+      symbol_coverage_penalty: 0.08
+    options:
+      fft:
+        window: "hann"
+        max_rel_band: 0.33
+      molecule_sets:
+        include: ["H2O","CO2","CH4","NH3"]
+      photonic:
+        use_fgs1_phase_anchor: true
+        jitter_robust: true
+  sigma:
+    calibration:
+      temperature_scaling: 1.05
+      corel_weight: 0.6
+      conformal_coverage_target: 0.70
+      per_bin: true
+  guards:
+    ood:
+      enable_entropy_tripwire: true
+      entropy_threshold: 1.20
+      zscore_threshold: 3.0
+      switch_to_profile: "ood_guardrails"
+  reporting:
+    export_masks: true
+    export_rule_scores: true


### PR DESCRIPTION
## Summary
- add symbolic profile index and planet-class-specific profile YAMLs
- implement auto-selection rules and JSON schema validators
- link active profiles to instruments, events, and competition modes

## Testing
- `pre-commit run --files configs/symbolic/overrides/profiles/README.md configs/symbolic/overrides/profiles/index.yaml configs/symbolic/overrides/profiles/profile_map.yaml configs/symbolic/overrides/profiles/default.profile.yaml configs/symbolic/overrides/profiles/hot_jupiter.profile.yaml configs/symbolic/overrides/profiles/ultra_hot_jupiter.profile.yaml configs/symbolic/overrides/profiles/warm_neptune.profile.yaml configs/symbolic/overrides/profiles/temperate_super_earth.profile.yaml configs/symbolic/overrides/profiles/ood_guardrails.profile.yaml configs/symbolic/overrides/_schemas/profile.schema.yaml configs/symbolic/overrides/_schemas/profile_map.schema.yaml configs/symbolic/overrides/instruments/link_profiles.yaml configs/symbolic/overrides/events/profile_switch.rules.yaml configs/symbolic/overrides/competition/profiles.yaml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'src')*

------
https://chatgpt.com/codex/tasks/task_e_689e63355c90832aad2bb00827eed572