### PR TITLE
SpectraMind V50: add symbolic profiles and domain rule sets

### DIFF
--- a/configs/symbolic/profiles/README.md
+++ b/configs/symbolic/profiles/README.md
@@ -1,0 +1,29 @@
+# SpectraMind V50 — Symbolic Profiles
+
+This directory contains Hydra YAML configs defining symbolic profiles for the
+neuro‑symbolic reasoning engine. A profile is a named collection of symbolic
+rules, weights, and domain tags used in training, calibration, and diagnostics.
+
+## Files
+- `base.yaml` — Canonical profile schema used by all profiles.
+- `default_physics.yaml` — Physics-informed constraints.
+- `default_astronomy.yaml` — Astronomy/transit‑spectroscopy constraints.
+- `default_patterns.yaml` — Pattern & fractal‑theory constraints.
+- `default_biology.yaml` — Cross-domain biological plausibility constraints.
+
+## Usage
+
+Select a profile via Hydra (examples):
+- Python module:
+  ```
+  python -m spectramind train_v50 symbolic.profile=default_astronomy
+  ```
+- Typer CLI:
+  ```
+  spectramind train --config-name=config_v50 symbolic.profile=default_physics
+  ```
+
+## Notes
+- Rule IDs listed in `rules.include` must exist under `configs/symbolic/rules/**`.
+- Weights can be overridden per-rule via `weights.overrides`.
+- Diagnostics flags integrate with SHAP overlays, HTML dashboards, and COREL.

--- a/configs/symbolic/profiles/base.yaml
+++ b/configs/symbolic/profiles/base.yaml
@@ -1,0 +1,42 @@
+# SpectraMind V50 — Symbolic Profiles Base Configuration
+#
+# Canonical schema for symbolic profile definitions.
+# Hydra-compatible; extend in domain-specific profiles via:
+# defaults:
+#   - base
+#
+# Fields are read by symbolic_logic_engine.py and training/diagnostics CLIs.
+
+profile:
+  version: "v50"
+  name: "base"
+  description: >
+    Root schema for symbolic profile definitions.
+    Profiles declare the symbolic rule set(s) and metadata controlling
+    how symbolic constraints are applied in training, calibration,
+    diagnostics, and explainability.
+
+  domains: []
+
+  rules:
+    include: []  # IDs of rules to enable (must exist under configs/symbolic/rules/**)
+    exclude: []  # IDs of rules to force-disable (wins over include)
+
+  weights:
+    default: 1.0         # Fallback weight if not overridden
+    overrides: {}        # Map: rule_id -> float
+
+  diagnostics:
+    symbolic_overlay: true   # Include symbolic overlays in dashboards/HTML
+    shap_fusion: true        # Fuse SHAP with symbolic rule heatmaps
+    export_masks: true       # Persist per-rule/bin masks for downstream tools
+    log_topk_rules: 5        # Log top-K contributing rules per sample
+
+  training:
+    loss_mode: "soft"        # "soft" or "hard"
+    normalize_losses: true   # Normalize per-rule losses by rule scale
+    curriculum:
+      enabled: true
+      warmup_epochs: 5
+      max_weight: 2.0
+      schedule: "linear"     # ["linear","cosine","step"]

--- a/configs/symbolic/profiles/default_astronomy.yaml
+++ b/configs/symbolic/profiles/default_astronomy.yaml
@@ -1,0 +1,45 @@
+# SpectraMind V50 — Default Astronomy Symbolic Profile
+#
+# Astronomy-grounded constraints tailored to Ariel-like transit spectroscopy.
+
+defaults:
+  - base
+
+profile:
+  name: "astronomy_default"
+  description: >
+    Astronomy-driven rules for space-based transit spectroscopy:
+    stellar baseline stability, physical transit depth bounds,
+    atmospheric absorption consistency, and Rayleigh slope behavior.
+
+  domains: ["astro"]
+
+  rules:
+    include:
+      - stellar_baseline_stability
+      - atmospheric_absorption_lines
+      - transit_depth_physical_range
+      - rayleigh_slope_consistency
+    exclude: []
+
+  weights:
+    default: 1.0
+    overrides:
+      stellar_baseline_stability: 1.5
+      atmospheric_absorption_lines: 2.0
+      transit_depth_physical_range: 1.8
+      rayleigh_slope_consistency: 1.0
+
+  diagnostics:
+    symbolic_overlay: true
+    shap_fusion: true
+    export_masks: true
+
+  training:
+    loss_mode: "soft"
+    normalize_losses: true
+    curriculum:
+      enabled: true
+      warmup_epochs: 3
+      max_weight: 2.2
+      schedule: "linear"

--- a/configs/symbolic/profiles/default_biology.yaml
+++ b/configs/symbolic/profiles/default_biology.yaml
@@ -1,0 +1,42 @@
+# SpectraMind V50 — Default Biology Symbolic Profile
+#
+# Cross-domain example profile for biological plausibility rules.
+
+defaults:
+  - base
+
+profile:
+  name: "biology_default"
+  description: >
+    Demonstration of biology-style constraints (mass balance, non-negativity,
+    kinetic limits) for cross-domain neuro-symbolic evaluation.
+
+  domains: ["biology"]
+
+  rules:
+    include:
+      - no_negative_concentration
+      - reaction_rate_limits
+      - conservation_of_mass
+    exclude: []
+
+  weights:
+    default: 1.0
+    overrides:
+      no_negative_concentration: 2.0
+      reaction_rate_limits: 1.5
+      conservation_of_mass: 2.5
+
+  diagnostics:
+    symbolic_overlay: true
+    shap_fusion: true
+    export_masks: true
+
+  training:
+    loss_mode: "soft"
+    normalize_losses: true
+    curriculum:
+      enabled: true
+      warmup_epochs: 4
+      max_weight: 2.0
+      schedule: "step"

--- a/configs/symbolic/profiles/default_patterns.yaml
+++ b/configs/symbolic/profiles/default_patterns.yaml
@@ -1,0 +1,42 @@
+# SpectraMind V50 — Default Patterns & Algorithms Symbolic Profile
+#
+# Pattern-theoretic constraints on spectra and latent embeddings.
+
+defaults:
+  - base
+
+profile:
+  name: "patterns_default"
+  description: >
+    Pattern-formation, symmetry, and scaling rules for spectral sequences
+    and latent spaces, supporting anomaly detection and shape priors.
+
+  domains: ["patterns"]
+
+  rules:
+    include:
+      - enforce_symmetry
+      - fractal_scaling
+      - golden_ratio_band_spacing
+    exclude: []
+
+  weights:
+    default: 1.0
+    overrides:
+      enforce_symmetry: 1.2
+      fractal_scaling: 1.0
+      golden_ratio_band_spacing: 0.8
+
+  diagnostics:
+    symbolic_overlay: true
+    shap_fusion: true
+    export_masks: true
+
+  training:
+    loss_mode: "soft"
+    normalize_losses: true
+    curriculum:
+      enabled: true
+      warmup_epochs: 2
+      max_weight: 1.6
+      schedule: "linear"

--- a/configs/symbolic/profiles/default_physics.yaml
+++ b/configs/symbolic/profiles/default_physics.yaml
@@ -1,0 +1,45 @@
+# SpectraMind V50 — Default Physics Symbolic Profile
+#
+# Physics-informed rules for atmospheric spectroscopy and transit modeling.
+
+defaults:
+  - base
+
+profile:
+  name: "physics_default"
+  description: >
+    Physics-informed constraints ensuring μ/σ predictions remain
+    physically plausible for exoplanetary spectra and time-series.
+
+  domains: ["physics", "astro"]
+
+  rules:
+    include:
+      - smoothness_constraint
+      - non_negativity_flux
+      - fft_bandlimit
+      - molecular_band_alignment
+    exclude: []
+
+  weights:
+    default: 1.0
+    overrides:
+      smoothness_constraint: 1.5
+      non_negativity_flux: 2.0
+      fft_bandlimit: 1.2
+      molecular_band_alignment: 1.0
+
+  diagnostics:
+    symbolic_overlay: true
+    shap_fusion: true
+    export_masks: true
+    log_topk_rules: 8
+
+  training:
+    loss_mode: "soft"
+    normalize_losses: true
+    curriculum:
+      enabled: true
+      warmup_epochs: 5
+      max_weight: 2.5
+      schedule: "cosine"

--- a/configs/symbolic/rules/README.md
+++ b/configs/symbolic/rules/README.md
@@ -1,0 +1,21 @@
+# SpectraMind V50 — Symbolic Rules
+
+Each YAML file defines a single rule with:
+- `rule.id` (unique), domain, kind, version, description
+- `inputs` (tensor or resource names expected by the engine)
+- `params` (tunable hyperparameters)
+- `loss` (type/aggregation) and diagnostics (export/overlay flags)
+
+Rule IDs referenced by profiles (e.g., `smoothness_constraint`) must match
+the `rule.id` field here exactly.
+
+## Folders
+- `physics/`  — physical and signal-processing constraints
+- `astro/`    — astronomy and transit‑spectroscopy constraints
+- `biology/`  — cross-domain demonstration constraints
+- `patterns/` — pattern-theoretic constraints
+
+These integrate with:
+- `symbolic_logic_engine.py`
+- diagnostics HTML (`generate_html_report.py`)
+- COREL/uncertainty calibration overlays

--- a/configs/symbolic/rules/astro/atmospheric_absorption_lines.yaml
+++ b/configs/symbolic/rules/astro/atmospheric_absorption_lines.yaml
@@ -1,0 +1,28 @@
+# Rule ID: atmospheric_absorption_lines
+#
+# Description: Reinforce presence/shape consistency of known atmospheric absorbers.
+
+rule:
+  id: "atmospheric_absorption_lines"
+  domain: "astro"
+  kind: "template/spectral_lines"
+  version: "v1"
+  description: >
+    Score consistency of predicted μ with libraries of atmospheric lines
+    (H2O, CO2, CH4, CO, NH3, HCN, TiO/VO where applicable).
+
+  inputs:
+    mu: "mu_spectrum"
+    line_lib: "atmo_line_library_v50.yaml"
+
+  params:
+    line_window_bins: 3
+    min_depth_ppm: 10.0
+    tolerance_ppm: 30.0
+
+  loss:
+    type: "softmatch"
+    aggregation: "weighted_mean_by_line_strength"
+
+  diagnostics:
+    export_line_hits: true

--- a/configs/symbolic/rules/astro/rayleigh_slope_consistency.yaml
+++ b/configs/symbolic/rules/astro/rayleigh_slope_consistency.yaml
@@ -1,0 +1,28 @@
+# Rule ID: rayleigh_slope_consistency
+#
+# Description: In blue/short λ regime, enforce approximate λ^-4 scattering slope when applicable.
+
+rule:
+  id: "rayleigh_slope_consistency"
+  domain: "astro"
+  kind: "shape/rayleigh"
+  version: "v1"
+  description: >
+    Fit local slope over short-λ segment; penalize deviations from expected trend
+    if atmosphere flagged as Rayleigh-dominated (metadata/flag).
+
+  inputs:
+    mu: "mu_spectrum"
+    wavelength: "wavelength_bins"   # [283] in microns
+    flags: "atmo_flags"             # contains rayleigh_candidate: bool
+
+  params:
+    lambda_max_um: 0.8
+    tolerance_ppm_per_um: 50.0
+
+  loss:
+    type: "robust_l1"
+    aggregation: "mean_over_flagged"
+
+  diagnostics:
+    overlay_html_dashboard: true

--- a/configs/symbolic/rules/astro/stellar_baseline_stability.yaml
+++ b/configs/symbolic/rules/astro/stellar_baseline_stability.yaml
@@ -1,0 +1,32 @@
+# Rule ID: stellar_baseline_stability
+#
+# Description: Constrain out-of-transit baseline drift/jitter for photometry time series.
+
+rule:
+  id: "stellar_baseline_stability"
+  domain: "astro"
+  kind: "time_series/stability"
+  version: "v1"
+  description: >
+    Penalize low-frequency drift and excessive RMS in out-of-transit segments,
+    accounting for known pointing jitter regressors if provided.
+
+  inputs:
+    flux_ts: "fgs1_flux_timeseries"     # [B, T]
+    oot_mask: "out_of_transit_mask"     # [B, T]
+    jitter: "pointing_jitter_ts"        # optional [B, T, 2]
+
+  params:
+    max_rms_ppm: 100.0
+    max_drift_ppm_per_hr: 50.0
+
+  loss:
+    type: "composite"
+    terms:
+      - name: "rms"
+        weight: 0.6
+      - name: "drift"
+        weight: 0.4
+
+  diagnostics:
+    export_timeplots: true

--- a/configs/symbolic/rules/astro/transit_depth_physical_range.yaml
+++ b/configs/symbolic/rules/astro/transit_depth_physical_range.yaml
@@ -1,0 +1,25 @@
+# Rule ID: transit_depth_physical_range
+#
+# Description: Enforce 0 <= depth(λ) <= depth_max from stellar/planet radius priors.
+
+rule:
+  id: "transit_depth_physical_range"
+  domain: "astro"
+  kind: "constraint/bounds"
+  version: "v1"
+  description: >
+    Depth bounds derived from (R_p/R_*)^2 ± uncertainty; softly penalize violations.
+
+  inputs:
+    depth_mu: "mu_spectrum"              # interpreted as depth(λ) in ppm or fraction
+    priors: "planet_star_radius_priors"  # provides depth_max per target
+
+  params:
+    margin_frac: 0.05        # allow small tolerance
+
+  loss:
+    type: "hinge_both_sides"
+    aggregation: "mean_over_violations"
+
+  diagnostics:
+    export_binwise_map: true

--- a/configs/symbolic/rules/biology/conservation_of_mass.yaml
+++ b/configs/symbolic/rules/biology/conservation_of_mass.yaml
@@ -1,0 +1,25 @@
+# Rule ID: conservation_of_mass
+#
+# Description: Enforce ∑inflows ≈ ∑outflows in closed system (demo).
+
+rule:
+  id: "conservation_of_mass"
+  domain: "biology"
+  kind: "conservation"
+  version: "v1"
+  description: >
+    Penalize mass imbalance given stoichiometry and closed-system assumption.
+
+  inputs:
+    inflow: "mass_in"
+    outflow: "mass_out"
+
+  params:
+    tolerance: 1.0e-6
+
+  loss:
+    type: "L2"
+    aggregation: "mean"
+
+  diagnostics:
+    export_mask: false

--- a/configs/symbolic/rules/biology/no_negative_concentration.yaml
+++ b/configs/symbolic/rules/biology/no_negative_concentration.yaml
@@ -1,0 +1,24 @@
+# Rule ID: no_negative_concentration
+#
+# Description: Non-negativity of species concentrations (demo cross-domain constraint).
+
+rule:
+  id: "no_negative_concentration"
+  domain: "biology"
+  kind: "constraint/inequality"
+  version: "v1"
+  description: >
+    Penalize negative predicted concentrations or derived quantities.
+
+  inputs:
+    x: "state_concentrations"   # placeholder tensor name
+
+  params:
+    margin: 0.0
+
+  loss:
+    type: "hinge"
+    aggregation: "mean"
+
+  diagnostics:
+    export_mask: false

--- a/configs/symbolic/rules/biology/reaction_rate_limits.yaml
+++ b/configs/symbolic/rules/biology/reaction_rate_limits.yaml
@@ -1,0 +1,24 @@
+# Rule ID: reaction_rate_limits
+#
+# Description: Bound reaction rates within physically plausible ranges.
+
+rule:
+  id: "reaction_rate_limits"
+  domain: "biology"
+  kind: "constraint/bounds"
+  version: "v1"
+  description: >
+    Soft bounds on |dx/dt| based on kinetic priors.
+
+  inputs:
+    dxdt: "reaction_rates"
+
+  params:
+    max_abs_rate: 10.0
+
+  loss:
+    type: "hinge_both_sides"
+    aggregation: "mean_over_violations"
+
+  diagnostics:
+    export_mask: false

--- a/configs/symbolic/rules/patterns/enforce_symmetry.yaml
+++ b/configs/symbolic/rules/patterns/enforce_symmetry.yaml
@@ -1,0 +1,25 @@
+# Rule ID: enforce_symmetry
+#
+# Description: Symmetry prior on paired spectral regions or latent pairs.
+
+rule:
+  id: "enforce_symmetry"
+  domain: "patterns"
+  kind: "shape/symmetry"
+  version: "v1"
+  description: >
+    Penalize asymmetry across configured mirror indices or latent pairings.
+
+  inputs:
+    x: "mu_spectrum"
+    symmetry_map: "symmetry_pairs_v50.yaml"  # list of index pairs
+
+  params:
+    norm: "l2"
+
+  loss:
+    type: "L2"
+    aggregation: "mean_over_pairs"
+
+  diagnostics:
+    export_pairwise_diff: true

--- a/configs/symbolic/rules/patterns/fractal_scaling.yaml
+++ b/configs/symbolic/rules/patterns/fractal_scaling.yaml
@@ -1,0 +1,29 @@
+# Rule ID: fractal_scaling
+#
+# Description: Encourage multi-scale consistency via downsampled self-similarity.
+
+rule:
+  id: "fractal_scaling"
+  domain: "patterns"
+  kind: "multiscale/self_similarity"
+  version: "v1"
+  description: >
+    Compare μ to pooled/downsampled versions; penalize large divergences.
+
+  inputs:
+    x: "mu_spectrum"
+
+  params:
+    scales: [2, 4]
+    metric: "cosine"    # ["l2","cosine"]
+
+  loss:
+    type: "composite"
+    terms:
+      - name: "scale2"
+        weight: 0.5
+      - name: "scale4"
+        weight: 0.5
+
+  diagnostics:
+    export_multiscale_curves: true

--- a/configs/symbolic/rules/patterns/golden_ratio_band_spacing.yaml
+++ b/configs/symbolic/rules/patterns/golden_ratio_band_spacing.yaml
@@ -1,0 +1,25 @@
+# Rule ID: golden_ratio_band_spacing
+#
+# Description: Optional heuristic spacing prior for clustered band centers.
+
+rule:
+  id: "golden_ratio_band_spacing"
+  domain: "patterns"
+  kind: "heuristic/spacing"
+  version: "v1"
+  description: >
+    When band centers are detected, prefer successive spacing ratios ~φ.
+
+  inputs:
+    band_centers: "detected_band_centers"  # indices
+
+  params:
+    phi: 1.61803398875
+    tolerance: 0.25
+
+  loss:
+    type: "robust_l1"
+    aggregation: "mean_over_pairs"
+
+  diagnostics:
+    export_band_table: true

--- a/configs/symbolic/rules/physics/fft_bandlimit.yaml
+++ b/configs/symbolic/rules/physics/fft_bandlimit.yaml
@@ -1,0 +1,26 @@
+# Rule ID: fft_bandlimit
+#
+# Description: Penalize high-frequency energy beyond configured cutoff in spectral domain.
+
+rule:
+  id: "fft_bandlimit"
+  domain: "physics"
+  kind: "regularizer/fft"
+  version: "v1"
+  description: >
+    Apply FFT to μ across wavelength index; penalize power above normalized cutoff.
+
+  inputs:
+    mu: "mu_spectrum"
+
+  params:
+    cutoff_frac: 0.35      # normalized Nyquist fraction
+    power_norm: "l2"       # ["l1","l2"]
+
+  loss:
+    type: "L2"
+    aggregation: "mean"
+
+  diagnostics:
+    export_power_spectrum: true
+    overlay_html_dashboard: true

--- a/configs/symbolic/rules/physics/molecular_band_alignment.yaml
+++ b/configs/symbolic/rules/physics/molecular_band_alignment.yaml
@@ -1,0 +1,31 @@
+# Rule ID: molecular_band_alignment
+#
+# Description: Encourage absorption minima at known molecular bands when SNR permits.
+
+rule:
+  id: "molecular_band_alignment"
+  domain: "physics"
+  kind: "template/multiple_bands"
+  version: "v1"
+  description: >
+    Softly attracts μ local minima toward known centers of H2O/CO2/CH4/CO/NH3 bands
+    with tolerance windows; disabled where SNR is below threshold.
+
+  inputs:
+    mu: "mu_spectrum"
+    snr: "snr_estimate_per_bin"   # optional [B, 283]
+    bands: "molecule_bands_v50.yaml"  # shared resource defining line centers/windows
+
+  params:
+    tol_bins: 2
+    min_snr: 2.0
+    attraction_strength: 0.5
+
+  loss:
+    type: "huber"
+    delta: 0.05
+    aggregation: "mean_over_hits"
+
+  diagnostics:
+    export_hit_table: true
+    overlay_symbols: true

--- a/configs/symbolic/rules/physics/non_negativity_flux.yaml
+++ b/configs/symbolic/rules/physics/non_negativity_flux.yaml
@@ -1,0 +1,26 @@
+# Rule ID: non_negativity_flux
+#
+# Description: Enforce μ and μ±kσ remain within non-negative physical flux domain.
+
+rule:
+  id: "non_negativity_flux"
+  domain: "physics"
+  kind: "constraint/inequality"
+  version: "v1"
+  description: >
+    Penalize negative μ and negative μ-κσ predictions; softly clamp with hinge loss.
+
+  inputs:
+    mu: "mu_spectrum"
+    sigma: "sigma_spectrum"      # [B, 283]
+
+  params:
+    kappa: 1.0
+    margin: 0.0
+
+  loss:
+    type: "hinge"
+    aggregation: "mean_over_valid"
+
+  diagnostics:
+    export_binwise_map: true

--- a/configs/symbolic/rules/physics/smoothness_constraint.yaml
+++ b/configs/symbolic/rules/physics/smoothness_constraint.yaml
@@ -1,0 +1,32 @@
+# Rule ID: smoothness_constraint
+#
+# Description: Penalize large second-derivative curvature in μ across wavelength bins
+# to enforce physically plausible smooth spectra while allowing sharp, known lines.
+
+rule:
+  id: "smoothness_constraint"
+  domain: "physics"
+  kind: "regularizer/laplacian"
+  version: "v1"
+  description: >
+    L2 penalty on discrete second differences of μ[λ] with optional
+    relaxed weighting inside registered molecular line windows.
+
+  inputs:
+    target: "mu_spectrum"     # [B, 283] predicted mean spectrum
+    mask: "valid_bins_mask"   # optional [B, 283]
+    aux:
+      molecular_windows: "molecule_windows_v50.yaml"  # optional path (Hydra-resolved)
+
+  params:
+    lambda: 1.0
+    line_window_relax: 0.5    # scale multiplier within known line windows
+    eps: 1.0e-12
+
+  loss:
+    type: "L2"
+    aggregation: "mean_over_valid"
+
+  diagnostics:
+    export_binwise_map: true
+    overlay_umap: true


### PR DESCRIPTION
## Summary
- Add base profile schema and default physics, astronomy, patterns, and biology profiles for symbolic training
- Introduce physics, astro, biology, and pattern rule YAMLs with diagnostics hooks
- Document symbolic profile and rule usage with README files

## Testing
- `pre-commit run --files $(git ls-files --others --exclude-standard)`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689e71c20758832a95b0dfb9462c6d7d