### PR TITLE
Add symbolic regions & overrides (V50 master-architect)

### DIFF
--- a/configs/symbolic/_schemas/symbolic_region.schema.json
+++ b/configs/symbolic/_schemas/symbolic_region.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Symbolic Region Schema",
+  "description": "Validation schema for SpectraMind V50 symbolic region definitions",
+  "type": "object",
+  "properties": {
+    "id": { "type": "string" },
+    "name": { "type": "string" },
+    "wavelength_range_um": {
+      "type": "array",
+      "items": { "type": "number" },
+      "minItems": 2,
+      "maxItems": 2
+    },
+    "type": { "type": ["string", "null"] },
+    "molecule": { "type": ["string", "null"] },
+    "symbolic_role": { "type": "string" },
+    "notes": { "type": ["string", "null"] }
+  },
+  "required": ["id", "name", "wavelength_range_um", "symbolic_role"]
+}

--- a/configs/symbolic/molecules/regions.yaml
+++ b/configs/symbolic/molecules/regions.yaml
@@ -1,0 +1,21 @@
+# =================================================================================================
+# File: configs/symbolic/molecules/regions.yaml
+# SpectraMind V50 — Molecule Registry (Regions X-Ref)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Provide a registry to cross-reference molecule shortcodes to the region pack for tooling.
+# =================================================================================================
+version: v50
+molecules:
+  H2O:
+    display: Water Vapor
+    primary_regions_ref: configs/symbolic/regions/molecular_regions.yaml
+  CO2:
+    display: Carbon Dioxide
+    primary_regions_ref: configs/symbolic/regions/molecular_regions.yaml
+  CH4:
+    display: Methane
+    primary_regions_ref: configs/symbolic/regions/molecular_regions.yaml
+  NH3:
+    display: Ammonia
+    primary_regions_ref: configs/symbolic/regions/molecular_regions.yaml

--- a/configs/symbolic/overrides/regions/README.md
+++ b/configs/symbolic/overrides/regions/README.md
@@ -1,0 +1,28 @@
+SpectraMind V50 — configs/symbolic/overrides/regions
+
+Hydra-compatible overlays controlling which symbolic region packs are active and how they are weighted.
+
+Files
+- default.yaml — Safe baseline; neutral weights; schema validation = warn.
+- molecules.yaml — Emphasizes molecular fingerprints (H2O/CO2/CH4/NH3).
+- telescope.yaml — Emphasizes channel/band integrity and cross-band continuity.
+- astrophysics.yaml — Emphasizes continuum/slope/thermal behavior.
+- challenge.yaml — Enables stress-test composites; strict validation; export to challenge bundle.
+- local.yaml — Fast-iter dev mode; JSON masks only; warnings not fatal.
+- kaggle.yaml — CI/leaderboard mode; strict; JSON masks to submission_bundle/.
+
+Usage
+
+Select an overlay via your Hydra defaults (example):
+
+```yaml
+# configs/config_v50.yaml (excerpt)
+defaults:
+  - symbolic/overrides/regions: default
+```
+
+Swap to other overlays by changing default → molecules, telescope, astrophysics, challenge,
+local, or kaggle.
+
+All packs reference canonical sources in configs/symbolic/regions/*.yaml and validate entries with
+configs/symbolic/_schemas/symbolic_region.schema.json.

--- a/configs/symbolic/overrides/regions/astrophysics.yaml
+++ b/configs/symbolic/overrides/regions/astrophysics.yaml
@@ -1,0 +1,40 @@
+# =================================================================================================
+# File: configs/symbolic/overrides/regions/astrophysics.yaml
+# SpectraMind V50 — Regions Override (Astrophysics)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Weight slope/continuum logic for atmospheric physics analyses and eclipse diagnostics.
+# =================================================================================================
+symbolic:
+  regions:
+    enabled: true
+    packs:
+      base: configs/symbolic/regions/regions_base.yaml
+      molecular: configs/symbolic/regions/molecular_regions.yaml
+      astrophysical: configs/symbolic/regions/astrophysical_regions.yaml
+      telescope: configs/symbolic/regions/telescope_regions.yaml
+      challenge: configs/symbolic/regions/challenge_regions.yaml
+
+    gates:
+      use_astrophysical: true
+      use_molecular: true
+      use_telescope: false
+      use_challenge: false
+
+    weights:
+      molecular_fingerprint: 0.9
+      continuum_reference: 1.5
+      near_ir_baseline: 1.3
+      scattering_reference: 1.6
+      thermal_baseline: 1.6
+      mixed_molecule_test: 0.6
+
+    validation:
+      enforce_schema: true
+      schema_path: configs/symbolic/_schemas/symbolic_region.schema.json
+      on_violation: "error"
+
+    exports:
+      write_masks_csv: true
+      write_masks_json: true
+      export_dir: artifacts/symbolic/regions_astrophysics

--- a/configs/symbolic/overrides/regions/challenge.yaml
+++ b/configs/symbolic/overrides/regions/challenge.yaml
@@ -1,0 +1,40 @@
+# =================================================================================================
+# File: configs/symbolic/overrides/regions/challenge.yaml
+# SpectraMind V50 — Regions Override (NeurIPS 2025 Challenge Mode)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Leaderboard/CI mode: turn on challenge composites and strict validation for robust submissions.
+# =================================================================================================
+symbolic:
+  regions:
+    enabled: true
+    packs:
+      base: configs/symbolic/regions/regions_base.yaml
+      molecular: configs/symbolic/regions/molecular_regions.yaml
+      astrophysical: configs/symbolic/regions/astrophysical_regions.yaml
+      telescope: configs/symbolic/regions/telescope_regions.yaml
+      challenge: configs/symbolic/regions/challenge_regions.yaml
+
+    gates:
+      use_astrophysical: true
+      use_molecular: true
+      use_telescope: true
+      use_challenge: true
+
+    weights:
+      molecular_fingerprint: 1.35
+      continuum_reference: 1.15
+      near_ir_baseline: 1.15
+      scattering_reference: 1.10
+      thermal_baseline: 1.10
+      mixed_molecule_test: 1.40
+
+    validation:
+      enforce_schema: true
+      schema_path: configs/symbolic/_schemas/symbolic_region.schema.json
+      on_violation: "error"
+
+    exports:
+      write_masks_csv: true
+      write_masks_json: true
+      export_dir: artifacts/symbolic/regions_challenge

--- a/configs/symbolic/overrides/regions/default.yaml
+++ b/configs/symbolic/overrides/regions/default.yaml
@@ -1,0 +1,44 @@
+# =================================================================================================
+# File: configs/symbolic/overrides/regions/default.yaml
+# SpectraMind V50 — Regions Override (Default)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Safe baseline that enables region packs with neutral weights. Use this as global default.
+# =================================================================================================
+symbolic:
+  regions:
+    enabled: true
+    packs:
+      base: configs/symbolic/regions/regions_base.yaml
+      molecular: configs/symbolic/regions/molecular_regions.yaml
+      astrophysical: configs/symbolic/regions/astrophysical_regions.yaml
+      telescope: configs/symbolic/regions/telescope_regions.yaml
+      challenge: configs/symbolic/regions/challenge_regions.yaml
+
+    # Global gating
+    gates:
+      use_astrophysical: true
+      use_molecular: true
+      use_telescope: true
+      use_challenge: false
+
+    # Neutral weights; downstream tools may re-weight
+    weights:
+      molecular_fingerprint: 1.0
+      continuum_reference: 1.0
+      near_ir_baseline: 1.0
+      scattering_reference: 1.0
+      thermal_baseline: 1.0
+      mixed_molecule_test: 1.0
+
+    # Validation controls (used by selftest & diagnostics)
+    validation:
+      enforce_schema: true
+      schema_path: configs/symbolic/_schemas/symbolic_region.schema.json
+      on_violation: "warn"   # ["error", "warn", "ignore"]
+
+    # Export hooks (UMAP/t-SNE overlays & HTML dashboard)
+    exports:
+      write_masks_csv: true
+      write_masks_json: true
+      export_dir: artifacts/symbolic/regions

--- a/configs/symbolic/overrides/regions/kaggle.yaml
+++ b/configs/symbolic/overrides/regions/kaggle.yaml
@@ -1,0 +1,40 @@
+# =================================================================================================
+# File: configs/symbolic/overrides/regions/kaggle.yaml
+# SpectraMind V50 — Regions Override (Kaggle/CI)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Turn on strict schema, ensure JSON masks, and route exports into submission bundle area.
+# =================================================================================================
+symbolic:
+  regions:
+    enabled: true
+    packs:
+      base: configs/symbolic/regions/regions_base.yaml
+      molecular: configs/symbolic/regions/molecular_regions.yaml
+      astrophysical: configs/symbolic/regions/astrophysical_regions.yaml
+      telescope: configs/symbolic/regions/telescope_regions.yaml
+      challenge: configs/symbolic/regions/challenge_regions.yaml
+
+    gates:
+      use_astrophysical: true
+      use_molecular: true
+      use_telescope: true
+      use_challenge: true
+
+    weights:
+      molecular_fingerprint: 1.2
+      continuum_reference: 1.1
+      near_ir_baseline: 1.1
+      scattering_reference: 1.1
+      thermal_baseline: 1.1
+      mixed_molecule_test: 1.3
+
+    validation:
+      enforce_schema: true
+      schema_path: configs/symbolic/_schemas/symbolic_region.schema.json
+      on_violation: "error"
+
+    exports:
+      write_masks_csv: false
+      write_masks_json: true
+      export_dir: submission_bundle/symbolic/regions

--- a/configs/symbolic/overrides/regions/local.yaml
+++ b/configs/symbolic/overrides/regions/local.yaml
@@ -1,0 +1,40 @@
+# =================================================================================================
+# File: configs/symbolic/overrides/regions/local.yaml
+# SpectraMind V50 — Regions Override (Local Dev Convenience)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Lightweight exports and permissive warnings for fast iteration on a laptop or dev VM.
+# =================================================================================================
+symbolic:
+  regions:
+    enabled: true
+    packs:
+      base: configs/symbolic/regions/regions_base.yaml
+      molecular: configs/symbolic/regions/molecular_regions.yaml
+      astrophysical: configs/symbolic/regions/astrophysical_regions.yaml
+      telescope: configs/symbolic/regions/telescope_regions.yaml
+      challenge: configs/symbolic/regions/challenge_regions.yaml
+
+    gates:
+      use_astrophysical: true
+      use_molecular: true
+      use_telescope: true
+      use_challenge: false
+
+    weights:
+      molecular_fingerprint: 1.0
+      continuum_reference: 1.0
+      near_ir_baseline: 1.0
+      scattering_reference: 1.0
+      thermal_baseline: 1.0
+      mixed_molecule_test: 1.0
+
+    validation:
+      enforce_schema: true
+      schema_path: configs/symbolic/_schemas/symbolic_region.schema.json
+      on_violation: "warn"
+
+    exports:
+      write_masks_csv: false
+      write_masks_json: true
+      export_dir: artifacts/symbolic/regions_local

--- a/configs/symbolic/overrides/regions/molecules.yaml
+++ b/configs/symbolic/overrides/regions/molecules.yaml
@@ -1,0 +1,40 @@
+# =================================================================================================
+# File: configs/symbolic/overrides/regions/molecules.yaml
+# SpectraMind V50 — Regions Override (Molecule-Focused)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Emphasize molecular detection windows for SHAP fusion, symbolic ranking, and COREL checks.
+# =================================================================================================
+symbolic:
+  regions:
+    enabled: true
+    packs:
+      base: configs/symbolic/regions/regions_base.yaml
+      molecular: configs/symbolic/regions/molecular_regions.yaml
+      astrophysical: configs/symbolic/regions/astrophysical_regions.yaml
+      telescope: configs/symbolic/regions/telescope_regions.yaml
+      challenge: configs/symbolic/regions/challenge_regions.yaml
+
+    gates:
+      use_astrophysical: false
+      use_molecular: true
+      use_telescope: true
+      use_challenge: true
+
+    weights:
+      molecular_fingerprint: 1.75
+      continuum_reference: 0.75
+      near_ir_baseline: 1.0
+      scattering_reference: 0.5
+      thermal_baseline: 0.9
+      mixed_molecule_test: 1.25
+
+    validation:
+      enforce_schema: true
+      schema_path: configs/symbolic/_schemas/symbolic_region.schema.json
+      on_violation: "error"
+
+    exports:
+      write_masks_csv: true
+      write_masks_json: true
+      export_dir: artifacts/symbolic/regions_molecules

--- a/configs/symbolic/overrides/regions/telescope.yaml
+++ b/configs/symbolic/overrides/regions/telescope.yaml
@@ -1,0 +1,40 @@
+# =================================================================================================
+# File: configs/symbolic/overrides/regions/telescope.yaml
+# SpectraMind V50 — Regions Override (Telescope/Instrument)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Focus on bandpass sanity, channel boundary effects, and cross-channel continuity.
+# =================================================================================================
+symbolic:
+  regions:
+    enabled: true
+    packs:
+      base: configs/symbolic/regions/regions_base.yaml
+      molecular: configs/symbolic/regions/molecular_regions.yaml
+      astrophysical: configs/symbolic/regions/astrophysical_regions.yaml
+      telescope: configs/symbolic/regions/telescope_regions.yaml
+      challenge: configs/symbolic/regions/challenge_regions.yaml
+
+    gates:
+      use_astrophysical: true
+      use_molecular: true
+      use_telescope: true
+      use_challenge: false
+
+    weights:
+      molecular_fingerprint: 1.1
+      continuum_reference: 1.4
+      near_ir_baseline: 1.4
+      scattering_reference: 1.2
+      thermal_baseline: 1.2
+      mixed_molecule_test: 0.8
+
+    validation:
+      enforce_schema: true
+      schema_path: configs/symbolic/_schemas/symbolic_region.schema.json
+      on_violation: "warn"
+
+    exports:
+      write_masks_csv: true
+      write_masks_json: true
+      export_dir: artifacts/symbolic/regions_telescope

--- a/configs/symbolic/regions/astrophysical_regions.yaml
+++ b/configs/symbolic/regions/astrophysical_regions.yaml
@@ -1,0 +1,22 @@
+# =================================================================================================
+# File: configs/symbolic/regions/astrophysical_regions.yaml
+# SpectraMind V50 — Astrophysical Symbolic Regions
+# --------------------------------------------------------------------------------
+# Purpose:
+# Regions describing astrophysical continuum or slope behavior used in symbolic rules.
+# =================================================================================================
+version: v50
+extends: regions_base.yaml
+description: Non-molecular regions for scattering and thermal emission constraints.
+
+astrophysical_regions:
+  - id: RAYLEIGH_SLOPE
+    name: Rayleigh Scattering Slope
+    wavelength_range_um: [0.50, 0.78]
+    symbolic_role: scattering_reference
+    notes: Short-λ slope; correlates with aerosols/haze in transmission.
+  - id: THERMAL_INFRARED
+    name: Thermal Emission Continuum
+    wavelength_range_um: [5.00, 7.80]
+    symbolic_role: thermal_baseline
+    notes: Secondary-eclipse dominant continuum for hot planets.

--- a/configs/symbolic/regions/challenge_regions.yaml
+++ b/configs/symbolic/regions/challenge_regions.yaml
@@ -1,0 +1,17 @@
+# =================================================================================================
+# File: configs/symbolic/regions/challenge_regions.yaml
+# SpectraMind V50 — NeurIPS 2025 Challenge Regions
+# --------------------------------------------------------------------------------
+# Purpose:
+# Synthetic / overlapped windows to stress-test disentanglement, calibration, and logic routing.
+# =================================================================================================
+version: v50
+extends: regions_base.yaml
+description: Challenge-focused composite and edge-case regions.
+
+challenge_regions:
+  - id: CHALLENGE_MIXED
+    name: Mixed Molecular Composite
+    wavelength_range_um: [1.95, 2.50]
+    symbolic_role: mixed_molecule_test
+    notes: Overlaps CH4 and CO2 to test rule disentanglement and masking.

--- a/configs/symbolic/regions/molecular_regions.yaml
+++ b/configs/symbolic/regions/molecular_regions.yaml
@@ -1,0 +1,20 @@
+# =================================================================================================
+# File: configs/symbolic/regions/molecular_regions.yaml
+# SpectraMind V50 — Molecular Symbolic Regions
+# --------------------------------------------------------------------------------
+# Purpose:
+# Defines wavelength sub-regions per molecule for rule masks, SHAP overlays, and fusion plots.
+# =================================================================================================
+version: v50
+extends: regions_base.yaml
+description: Molecular wavelength clusters for symbolic constraints and diagnostics.
+
+molecular_regions:
+  - molecule: H2O
+    regions: [[0.92, 1.15], [1.35, 1.50], [1.80, 2.00]]
+  - molecule: CO2
+    regions: [[1.95, 2.10], [4.20, 4.40]]
+  - molecule: CH4
+    regions: [[1.65, 1.80], [2.20, 2.50], [3.30, 3.50]]
+  - molecule: NH3
+    regions: [[1.50, 1.65], [2.90, 3.10]]

--- a/configs/symbolic/regions/regions_base.yaml
+++ b/configs/symbolic/regions/regions_base.yaml
@@ -1,0 +1,50 @@
+# =================================================================================================
+# File: configs/symbolic/regions/regions_base.yaml
+# SpectraMind V50 — Symbolic Region Definitions (Base, Hydra-safe)
+# --------------------------------------------------------------------------------
+# Purpose:
+# Canonical symbolic region definitions used by symbolic logic, diagnostics, masking, and
+# molecular alignment. All region entries adhere to _schemas/symbolic_region.schema.json.
+#
+# Conventions:
+# - wavelength_range_um is [start_um, end_um] inclusive of interior, half-open at end in code.
+# - type ∈ {telescope_band, molecule, astrophysical}
+# - symbolic_role provides semantic routing for rule engines and diagnostics overlays.
+# =================================================================================================
+version: v50
+description: Canonical symbolic region definitions for SpectraMind V50.
+
+regions:
+  - id: VIS
+    name: Visible Light Band
+    wavelength_range_um: [0.50, 0.78]
+    type: telescope_band
+    symbolic_role: continuum_reference
+    notes: Visible photometry baseline and guidance reference.
+  - id: NIR
+    name: Near-Infrared Band
+    wavelength_range_um: [0.78, 2.50]
+    type: telescope_band
+    symbolic_role: near_ir_baseline
+    notes: Overlaps multiple molecular bands; useful for slope and baseline checks.
+  - id: CH4_CORE
+    name: Methane Absorption Core
+    wavelength_range_um: [2.20, 2.50]
+    type: molecule
+    molecule: CH4
+    symbolic_role: molecular_fingerprint
+    notes: Strong CH4 signature region.
+  - id: CO2_PRIMARY
+    name: Carbon Dioxide Primary Band
+    wavelength_range_um: [4.20, 4.40]
+    type: molecule
+    molecule: CO2
+    symbolic_role: molecular_fingerprint
+    notes: High-SNR CO2 window; used in CO2-CH4 logic interplay.
+  - id: H2O_MAIN
+    name: Water Vapor Main Band
+    wavelength_range_um: [1.35, 1.50]
+    type: molecule
+    molecule: H2O
+    symbolic_role: molecular_fingerprint
+    notes: Primary H2O absorption cluster for transmission spectroscopy.

--- a/configs/symbolic/regions/telescope_regions.yaml
+++ b/configs/symbolic/regions/telescope_regions.yaml
@@ -1,0 +1,31 @@
+# =================================================================================================
+# File: configs/symbolic/regions/telescope_regions.yaml
+# SpectraMind V50 — Telescope Instrument Regions
+# --------------------------------------------------------------------------------
+# Purpose:
+# Bind ARIEL channels to symbolic regions for unified rule/diagnostics routing.
+# =================================================================================================
+version: v50
+extends: regions_base.yaml
+description: ARIEL FGS/AIRS channel symbolic references.
+
+telescope_regions:
+  FGS1_VIS:
+    wavelength_range_um: [0.50, 0.78]
+    symbolic_ref: VIS
+
+  FGS1_NIR:
+    wavelength_range_um: [0.78, 1.10]
+    symbolic_ref: NIR
+
+  AIRS_CH1:
+    wavelength_range_um: [1.10, 1.95]
+    symbolic_ref: H2O_MAIN
+
+  AIRS_CH2:
+    wavelength_range_um: [1.95, 3.90]
+    symbolic_ref: CH4_CORE
+
+  AIRS_CH3:
+    wavelength_range_um: [3.90, 7.80]
+    symbolic_ref: THERMAL_INFRARED


### PR DESCRIPTION
## Summary
- add canonical region definitions and grouped molecular/astrophysical/telescope/challenge stacks
- define JSON schema and molecule registry for region lookup
- introduce Hydra override presets for default, molecule-focused, telescope, astrophysics, challenge, local, and kaggle modes

## Testing
- `pre-commit run --files configs/symbolic/regions/regions_base.yaml configs/symbolic/regions/molecular_regions.yaml configs/symbolic/regions/astrophysical_regions.yaml configs/symbolic/regions/telescope_regions.yaml configs/symbolic/regions/challenge_regions.yaml configs/symbolic/_schemas/symbolic_region.schema.json configs/symbolic/molecules/regions.yaml configs/symbolic/overrides/regions/default.yaml configs/symbolic/overrides/regions/molecules.yaml configs/symbolic/overrides/regions/telescope.yaml configs/symbolic/overrides/regions/astrophysics.yaml configs/symbolic/overrides/regions/challenge.yaml configs/symbolic/overrides/regions/local.yaml configs/symbolic/overrides/regions/kaggle.yaml configs/symbolic/overrides/regions/README.md`


------
https://chatgpt.com/codex/tasks/task_e_689e742ab520832aac8e7bb615f92540