### PR TITLE
feat: add challenge-grade ci pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,168 +1,120 @@
-name: ci
+name: SpectraMind V50 CI
 
 on:
-push:
-branches: [ main, master, develop, “release/” ]
-pull_request:
-branches: [ “” ]
-
-permissions:
-contents: read
-
-concurrency:
-group: ci-${{ github.workflow }}-${{ github.ref }}
-cancel-in-progress: true
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch:
 
 env:
-PYTHONUTF8: “1”
-PIP_DISABLE_PIP_VERSION_CHECK: “1”
-PIP_NO_PYTHON_VERSION_WARNING: “1”
-POETRY_VERSION: “1.8.3”
+  PYTHON_VERSION: '3.11'
+  POETRY_VERSION: '1.8.3'
 
 jobs:
-setup:
-name: Setup & Cache
-runs-on: ubuntu-latest
-outputs:
-python-version: ${{ steps.meta.outputs.python-version }}
-steps:
-- name: Select Python
-id: meta
-run: echo “python-version=3.11” >> “$GITHUB_OUTPUT”
+  setup:
+    name: Setup Environment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-lint:
-name: Lint (ruff)
-runs-on: ubuntu-latest
-needs: setup
-steps:
-- uses: actions/checkout@v4
-with: { fetch-depth: 0 }
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-  - name: Setup Python ${{ needs.setup.outputs.python-version }}
-    uses: actions/setup-python@v5
-    with:
-      python-version: ${{ needs.setup.outputs.python-version }}
+      - name: Install Poetry
+        run: pip install poetry==${{ env.POETRY_VERSION }}
 
-  - name: Install Poetry ${{ env.POETRY_VERSION }}
-    run: |
-      python -m pip install -U pip
-      python -m pip install "poetry==${POETRY_VERSION}"
-      poetry --version
-      poetry config virtualenvs.in-project true
+      - name: Cache Poetry venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
 
-  - name: Cache Poetry virtualenv
-    id: cache-poetry
-    uses: actions/cache@v4
-    with:
-      path: ./.venv
-      key: venv-${{ runner.os }}-${{ needs.setup.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Install dependencies
+        run: poetry install --with dev --no-interaction
 
-  - name: Install deps (poetry)
-    run: |
-      poetry install --no-interaction --no-ansi
-  - name: Ruff lint
-    run: |
-      ./.venv/bin/ruff --version
-      ./.venv/bin/ruff . --output-format=github
+  lint:
+    name: Lint & Static Analysis
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+      - name: Run flake8
+        run: poetry run flake8 src/ tests/
+      - name: Run mypy
+        run: poetry run mypy src/
 
-test:
-name: Unit Tests (pytest)
-runs-on: ubuntu-latest
-needs: [setup, lint]
-steps:
-- uses: actions/checkout@v4
-with: { fetch-depth: 0 }
+  test:
+    name: Unit & Integration Tests
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+      - name: Run pytest
+        run: poetry run pytest --maxfail=1 --disable-warnings -q --cov=src --cov-report=xml
 
-  - name: Setup Python ${{ needs.setup.outputs.python-version }}
-    uses: actions/setup-python@v5
-    with:
-      python-version: ${{ needs.setup.outputs.python-version }}
+  reproducibility:
+    name: Reproducibility & Selftest
+    runs-on: ubuntu-latest
+    needs: test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+      - name: Run selftest
+        run: poetry run python src/spectramind/cli/selftest.py --deep --json-out ci_selftest.json
 
-  - name: Install Poetry ${{ env.POETRY_VERSION }}
-    run: |
-      python -m pip install -U pip
-      python -m pip install "poetry==${POETRY_VERSION}"
-      poetry config virtualenvs.in-project true
+  diagnostics:
+    name: Diagnostics & HTML Dashboard
+    runs-on: ubuntu-latest
+    needs: reproducibility
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+      - name: Generate diagnostics dashboard
+        run: |
+          poetry run spectramind diagnose dashboard --no-browser --output-html ci_diagnostics.html
+      - name: Upload HTML dashboard
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostics-dashboard
+          path: ci_diagnostics.html
 
-  - name: Cache Poetry virtualenv
-    id: cache-poetry
-    uses: actions/cache@v4
-    with:
-      path: ./.venv
-      key: venv-${{ runner.os }}-${{ needs.setup.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-  - name: Install deps (poetry)
-    run: |
-      poetry install --no-interaction --no-ansi
-
-  - name: Run pytest
-    run: |
-      ./.venv/bin/python -m pytest -q
-
-smoke:
-name: Smoke E2E (CLI)
-runs-on: ubuntu-latest
-needs: [setup, test]
-steps:
-- uses: actions/checkout@v4
-with: { fetch-depth: 0 }
-
-  - name: Setup Python ${{ needs.setup.outputs.python-version }}
-    uses: actions/setup-python@v5
-    with:
-      python-version: ${{ needs.setup.outputs.python-version }}
-
-  - name: Install Poetry ${{ env.POETRY_VERSION }}
-    run: |
-      python -m pip install -U pip
-      python -m pip install "poetry==${POETRY_VERSION}"
-      poetry config virtualenvs.in-project true
-
-  - name: Cache Poetry virtualenv
-    id: cache-poetry
-    uses: actions/cache@v4
-    with:
-      path: ./.venv
-      key: venv-${{ runner.os }}-${{ needs.setup.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-
-  - name: Install deps (poetry)
-    run: |
-      poetry install --no-interaction --no-ansi
-
-  - name: CLI — version & selftest
-    run: |
-      ./.venv/bin/python -m spectramind --version
-      ./.venv/bin/python -m spectramind selftest
-
-  - name: CLI — dry diagnostics
-    continue-on-error: true
-    run: |
-      ./.venv/bin/python -m spectramind diagnose
-
-  - name: CLI — predict stub & package
-    run: |
-      ./.venv/bin/python -m spectramind predict --out-csv outputs/submission.csv
-      ./.venv/bin/python -m spectramind submit bundle
-
-  - name: Upload submission & logs
-    uses: actions/upload-artifact@v4
-    with:
-      name: spectramind-outputs
-      path: |
-        outputs/submission.csv
-        outputs/submission_bundle.zip
-        v50_debug_log.md
-        events.jsonl
-      if-no-files-found: warn
-
-summary:
-name: CI Summary
-runs-on: ubuntu-latest
-needs: [lint, test, smoke]
-if: always()
-steps:
-- name: Build result
-run: |
-echo “Lint:  ${{ needs.lint.result }}”  >> $GITHUB_STEP_SUMMARY
-echo “Tests: ${{ needs.test.result }}”  >> $GITHUB_STEP_SUMMARY
-echo “Smoke: ${{ needs.smoke.result }}” >> $GITHUB_STEP_SUMMARY
+  submit-check:
+    name: Submission Validation
+    runs-on: ubuntu-latest
+    needs: diagnostics
+    steps:
+      - uses: actions/checkout@v4
+      - name: Restore venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ env.PYTHON_VERSION }}-${{ hashFiles('poetry.lock') }}
+      - name: Validate submission package
+        run: poetry run spectramind submit --selftest --dry-run


### PR DESCRIPTION
## Summary
- replace existing CI with challenge-grade SpectraMind V50 pipeline
- add reproducibility, diagnostics, and submission validation stages

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_689e8f678158832a9e3a85b3fcdd72ca