### PR TITLE
feat: add calibration toolkit

### DIFF
--- a/src/spectramind/calibration/README.md
+++ b/src/spectramind/calibration/README.md
@@ -1,0 +1,38 @@
+# SpectraMind V50 – Calibration Package
+
+Mission-grade calibration kill-chain for Ariel-style instruments (FGS1/AIRS), engineered for reproducibility and diagnostics.
+
+## Features
+
+- ADC, nonlinearity, dark, flat-field and cosmic ray removal
+- Spectral trace alignment with optional sub-pixel refinement
+- Photometry (aperture/optimal) and phase normalisation
+- Symbolic calibration (non-negativity, spectral smoothing)
+- σ calibration tools: temperature scaling + conformal bin-wise calibration
+- Typer CLI with `run`, `batch`, `sigma-calibrate`, `validate` and `selftest`
+- Console + rotating file logs and JSONL event stream
+- Reproducibility snapshot (Git/ENV capture) and markdown debug log
+
+## Minimal Usage
+
+```bash
+python -m spectramind.calibration.calibration_cli selftest
+python -m spectramind.calibration.calibration_cli run artifacts/calibration/SELF_AIRS_cube.npy --instrument AIRS
+python -m spectramind.calibration.calibration_cli batch artifacts/calibration
+```
+
+## Config
+
+See `calibration_config.py` for Hydra-safe dataclasses. `CalibrationConfig.from_yaml()` loads configuration from YAML.
+
+## Outputs
+
+- `artifacts/calibration/{INST}_flux.npy`
+- `artifacts/calibration/{INST}_flux_err.npy`
+- `artifacts/calibration/{INST}_cube_calibrated.npy`
+- `artifacts/calibration/calibration_run.json` or `calibration_batch.json`
+- Logs in `logs/`, JSONL event stream in `logs/calibration_events.jsonl`
+
+## License
+
+Apache-2.0

--- a/src/spectramind/calibration/__init__.py
+++ b/src/spectramind/calibration/__init__.py
@@ -1,1 +1,21 @@
+"""SpectraMind V50 — Calibration Package
 
+Exports and package metadata.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version as _pkg_version
+
+__all__ = [
+    "Calibrator",
+    "run_calibration_batch",
+    "run_calibration_one",
+]
+
+try:
+    version = _pkg_version("spectramind")
+except Exception:  # pragma: no cover - package not installed
+    version = "0.0.0-dev"
+
+from .pipeline import Calibrator, run_calibration_batch, run_calibration_one  # noqa: E402,F401

--- a/src/spectramind/calibration/adc_correction.py
+++ b/src/spectramind/calibration/adc_correction.py
@@ -1,0 +1,15 @@
+"""Analog-to-digital conversion (ADC) correction."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .calibration_config import ADCConfig
+
+
+def apply_adc_correction(cube: np.ndarray, cfg: ADCConfig) -> np.ndarray:
+    """Linear ADC correction: ``out = (cube - bias) * gain``."""
+
+    if not cfg.enabled:
+        return cube
+    return (cube - cfg.bias) * cfg.gain

--- a/src/spectramind/calibration/calibration_checker.py
+++ b/src/spectramind/calibration/calibration_checker.py
@@ -1,0 +1,31 @@
+"""Metrics and utilities for sigma calibration evaluation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+
+
+def evaluate_sigma_calibration(
+    mu_pred: np.ndarray, mu_true: np.ndarray, sigma_pred: np.ndarray
+) -> Dict[str, Any]:
+    resid = mu_pred - mu_true
+    z = resid / (sigma_pred + 1e-9)
+    return {
+        "coverage_68": float(np.mean(np.abs(z) <= 1.0)),
+        "coverage_95": float(np.mean(np.abs(z) <= 2.0)),
+        "rmse": float(np.sqrt(np.mean(resid ** 2))),
+        "mae": float(np.mean(np.abs(resid))),
+        "z_mean": float(np.mean(z)),
+        "z_std": float(np.std(z)),
+    }
+
+
+def save_summary_json(summary: Dict[str, Any], out_path: str | Path) -> None:
+    p = Path(out_path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    with open(p, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2)

--- a/src/spectramind/calibration/calibration_cli.py
+++ b/src/spectramind/calibration/calibration_cli.py
@@ -1,0 +1,125 @@
+"""Typer-based command line interface for the calibration package."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import typer
+
+from .calibration_checker import evaluate_sigma_calibration, save_summary_json
+from .calibration_config import CalibrationConfig
+from .corel_calibration import conformal_calibrate_sigma
+from .git_env_capture import reproducibility_snapshot
+from .logging_utils import append_debug_md, setup_logging
+from .pipeline import run_calibration_batch, run_calibration_one
+from .temperature_scaling import apply_temperature_scaling, fit_temperature_scaling
+
+app = typer.Typer(no_args_is_help=True, add_completion=False, help="SpectraMind V50 Calibration CLI")
+
+
+@app.command("run")
+def cmd_run(
+    cube_path: str = typer.Argument(..., help="Path to .npy cube (T,H,W)"),
+    instrument: str = typer.Option("AIRS", help="Instrument name"),
+    exposure_s: float = typer.Option(1.0, help="Exposure duration in seconds"),
+    config_yaml: Optional[str] = typer.Option(None, help="Hydra/OmegaConf YAML for calibration config"),
+    output_dir: Optional[str] = typer.Option(None, help="Override output dir"),
+) -> None:
+    cfg = CalibrationConfig.from_yaml(config_yaml) if config_yaml else CalibrationConfig()
+    if output_dir:
+        cfg.io.output_dir = output_dir
+    res = run_calibration_one(
+        cube_path=cube_path, instrument=instrument, cfg=cfg, exposure_s=exposure_s
+    )
+    typer.echo(json.dumps({"instrument": instrument, "cr_replaced": res.get("cr_replaced", 0)}, indent=2))
+
+
+@app.command("batch")
+def cmd_batch(
+    input_dir: str = typer.Argument(..., help="Directory containing .npy cubes"),
+    exposure_s: float = typer.Option(1.0, help="Exposure duration in seconds"),
+    config_yaml: Optional[str] = typer.Option(None, help="Hydra/OmegaConf YAML for calibration config"),
+    output_dir: Optional[str] = typer.Option(None, help="Override output dir"),
+) -> None:
+    cfg = CalibrationConfig.from_yaml(config_yaml) if config_yaml else CalibrationConfig()
+    if output_dir:
+        cfg.io.output_dir = output_dir
+    manifest = run_calibration_batch(input_dir=input_dir, cfg=cfg, exposure_s=exposure_s)
+    typer.echo(json.dumps(manifest, indent=2))
+
+
+@app.command("sigma-calibrate")
+def cmd_sigma_calibrate(
+    mu_pred_path: str = typer.Argument(..., help="Path to μ predictions .npy"),
+    mu_true_path: str = typer.Argument(..., help="Path to μ ground truth .npy"),
+    sigma_pred_path: str = typer.Argument(..., help="Path to σ predictions .npy"),
+    alpha: float = typer.Option(0.1, help="Conformal risk level"),
+    out_sigma_path: str = typer.Option("artifacts/calibration/sigma_calibrated.npy", help="Output path"),
+    temperature: bool = typer.Option(True, help="Fit global temperature scaling first"),
+) -> None:
+    logger, evt = setup_logging()
+    mu_pred = np.load(mu_pred_path)
+    mu_true = np.load(mu_true_path)
+    sigma_pred = np.load(sigma_pred_path)
+
+    if temperature:
+        T = fit_temperature_scaling(mu_pred - mu_true, sigma_pred)
+        sigma_pred = apply_temperature_scaling(sigma_pred, T)
+        evt.log({"event": "temperature_scaling", "T": float(T)})
+        logger.info(f"Temperature scaling T={T:.4f}")
+
+    sigma_cal, meta = conformal_calibrate_sigma(mu_pred, mu_true, sigma_pred, alpha=alpha)
+    Path(out_sigma_path).parent.mkdir(parents=True, exist_ok=True)
+    np.save(out_sigma_path, sigma_cal)
+
+    summary = evaluate_sigma_calibration(mu_pred, mu_true, sigma_cal)
+    out_json = str(Path(out_sigma_path).with_suffix(".json"))
+    save_summary_json(summary | {"meta": meta}, out_json)
+    typer.echo(json.dumps({"out_sigma": out_sigma_path, "summary": summary, "meta": meta}, indent=2))
+
+
+@app.command("validate")
+def cmd_validate(
+    mu_pred_path: str = typer.Argument(...),
+    mu_true_path: str = typer.Argument(...),
+    sigma_path: str = typer.Argument(...),
+    out_json: str = typer.Option("artifacts/calibration/calibration_summary.json", help="Summary JSON"),
+) -> None:
+    mu_pred = np.load(mu_pred_path)
+    mu_true = np.load(mu_true_path)
+    sigma = np.load(sigma_path)
+    summary = evaluate_sigma_calibration(mu_pred, mu_true, sigma)
+    save_summary_json(summary, out_json)
+    typer.echo(json.dumps(summary, indent=2))
+
+
+@app.command("selftest")
+def cmd_selftest() -> None:
+    logger, evt = setup_logging()
+    append_debug_md("Calibration Self-Test", reproducibility_snapshot())
+    T, H, W = 64, 32, 32
+    rng = np.random.default_rng(1337)
+    base = rng.normal(1000, 5, size=(T, H, W)).astype(np.float32)
+    y, x = np.mgrid[0:H, 0:W]
+    psf = np.exp(-((x - W / 2) ** 2 + (y - H / 2) ** 2) / (2 * 3.0 ** 2))
+    psf /= psf.sum()
+    for t in range(T):
+        base[t] += 500 * psf
+    flux_true = np.ones(T)
+    flux_true[24:40] -= 0.01
+    for t in range(T):
+        base[t] *= flux_true[t]
+    cfg = CalibrationConfig()
+    out_dir = Path(cfg.io.output_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    cube_path = out_dir / "SELF_AIRS_cube.npy"
+    np.save(cube_path, base)
+    res = run_calibration_one(str(cube_path), instrument="AIRS", cfg=cfg, exposure_s=1.0)
+    typer.echo(json.dumps({"ok": True, "cr_replaced": res.get("cr_replaced", 0)}, indent=2))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/spectramind/calibration/calibration_config.py
+++ b/src/spectramind/calibration/calibration_config.py
@@ -1,0 +1,141 @@
+"""Hydra-safe calibration configuration dataclasses."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, List, Literal, Optional
+
+
+@dataclass
+class ADCConfig:
+    enabled: bool = True
+    bias: float = 0.0
+    gain: float = 1.0
+
+
+@dataclass
+class NonlinearityConfig:
+    enabled: bool = True
+    coeffs: List[float] = field(default_factory=lambda: [0.0, 1.0, 0.0])
+
+
+@dataclass
+class DarkConfig:
+    enabled: bool = True
+    method: Literal["frame", "model"] = "frame"
+    frame_path: Optional[str] = None
+    temperature_K: Optional[float] = None
+    dark_rate_e_per_s: float = 0.0
+
+
+@dataclass
+class FlatConfig:
+    enabled: bool = True
+    frame_path: Optional[str] = None
+    eps: float = 1e-8
+
+
+@dataclass
+class CosmicConfig:
+    enabled: bool = True
+    sigma: float = 5.0
+    time_window: int = 3
+
+
+@dataclass
+class PhotometryConfig:
+    method: Literal["aperture", "optimal"] = "aperture"
+    aperture_radius_px: int = 6
+    background_inner_px: int = 10
+    background_outer_px: int = 14
+
+
+@dataclass
+class AlignmentConfig:
+    enabled: bool = True
+    ref: Literal["FGS1", "AIRS", "auto"] = "auto"
+    subpixel: bool = True
+    max_shift_px: int = 3
+
+
+@dataclass
+class NormalizationConfig:
+    enabled: bool = True
+    method: Literal["median-oot", "poly"] = "median-oot"
+    poly_order: int = 2
+    oot_frac: float = 0.2
+
+
+@dataclass
+class JitterInjectionConfig:
+    enabled: bool = False
+    std_px: float = 0.2
+    seed: int = 1337
+
+
+@dataclass
+class SymbolicCalibrationConfig:
+    enabled: bool = True
+    nonnegativity: bool = True
+    smooth_window: int = 5
+    smooth_axis: Literal["time", "wavelength"] = "wavelength"
+
+
+@dataclass
+class SigmaCalibrationConfig:
+    temperature_scaling: bool = True
+    corel: bool = True
+
+
+@dataclass
+class IOConfig:
+    input_dir: Optional[str] = None
+    output_dir: str = "artifacts/calibration"
+    overwrite: bool = True
+
+
+@dataclass
+class CalibrationConfig:
+    adc: ADCConfig = field(default_factory=ADCConfig)
+    nonlin: NonlinearityConfig = field(default_factory=NonlinearityConfig)
+    dark: DarkConfig = field(default_factory=DarkConfig)
+    flat: FlatConfig = field(default_factory=FlatConfig)
+    cosmic: CosmicConfig = field(default_factory=CosmicConfig)
+    photometry: PhotometryConfig = field(default_factory=PhotometryConfig)
+    align: AlignmentConfig = field(default_factory=AlignmentConfig)
+    norm: NormalizationConfig = field(default_factory=NormalizationConfig)
+    jitter: JitterInjectionConfig = field(default_factory=JitterInjectionConfig)
+    symbolic: SymbolicCalibrationConfig = field(default_factory=SymbolicCalibrationConfig)
+    sigma_calib: SigmaCalibrationConfig = field(default_factory=SigmaCalibrationConfig)
+    io: IOConfig = field(default_factory=IOConfig)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @staticmethod
+    def from_yaml(path: str) -> "CalibrationConfig":
+        try:
+            from omegaconf import OmegaConf  # type: ignore
+
+            cfg = OmegaConf.load(path)
+            data = OmegaConf.to_container(cfg, resolve=True)
+        except Exception:
+            import yaml  # type: ignore
+
+            with open(path, "r", encoding="utf-8") as f:
+                data = yaml.safe_load(f)
+
+        def merge(dc: Any, dd: Dict[str, Any]) -> None:
+            for k, v in dd.items():
+                if hasattr(dc, k):
+                    field_val = getattr(dc, k)
+                    if isinstance(v, dict) and not isinstance(
+                        field_val, (str, int, float, bool, type(None))
+                    ):
+                        merge(field_val, v)
+                    else:
+                        setattr(dc, k, v)
+
+        cfg_dc = CalibrationConfig()
+        merge(cfg_dc, data or {})
+        return cfg_dc

--- a/src/spectramind/calibration/corel_calibration.py
+++ b/src/spectramind/calibration/corel_calibration.py
@@ -1,0 +1,33 @@
+"""Conformal risk calibration for uncertainty estimates."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def conformal_calibrate_sigma(
+    mu_pred: np.ndarray,
+    mu_true: np.ndarray,
+    sigma_pred: np.ndarray,
+    alpha: float = 0.1,
+) -> tuple[np.ndarray, dict]:
+    """Perform a simple bin-wise conformal calibration of sigma."""
+
+    r = np.abs(mu_pred - mu_true)
+    if r.ndim == 2:
+        q_alpha = np.quantile(r, 1 - alpha, axis=0)
+        sigma_ref = np.maximum(
+            sigma_pred.mean(axis=0) if sigma_pred.ndim == 2 else sigma_pred, 1e-9
+        )
+    else:
+        q_alpha = float(np.quantile(r, 1 - alpha))
+        sigma_ref = np.maximum(np.mean(sigma_pred), 1e-9)
+
+    scale = q_alpha / sigma_ref
+    sigma_cal = sigma_pred * scale
+    meta = {
+        "alpha": alpha,
+        "q_alpha": q_alpha.tolist() if hasattr(q_alpha, "tolist") else float(q_alpha),
+        "scale_mean": float(np.mean(scale)),
+    }
+    return sigma_cal, meta

--- a/src/spectramind/calibration/cosmic_ray_removal.py
+++ b/src/spectramind/calibration/cosmic_ray_removal.py
@@ -1,0 +1,32 @@
+"""Cosmic ray removal via temporal sigma clipping."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .calibration_config import CosmicConfig
+
+
+def remove_cosmics_sigma_clip(cube: np.ndarray, cfg: CosmicConfig) -> tuple[np.ndarray, np.ndarray]:
+    """Sigma-clip outliers in time for each pixel."""
+
+    if not cfg.enabled:
+        return cube, np.zeros_like(cube, dtype=np.uint8)
+
+    T = cube.shape[0]
+    median = np.median(cube, axis=0, keepdims=True)
+    mad = np.median(np.abs(cube - median), axis=0, keepdims=True) + 1e-9
+    z = (cube - median) / (1.4826 * mad)
+    mask = (np.abs(z) > cfg.sigma).astype(np.uint8)
+
+    clean = cube.copy()
+    w = cfg.time_window
+    for t in range(T):
+        bad = mask[t] > 0
+        if not bad.any():
+            continue
+        t0, t1 = max(0, t - w), min(T, t + w + 1)
+        neigh = cube[t0:t1]
+        rep = np.median(neigh, axis=0)
+        clean[t][bad] = rep[bad]
+    return clean, mask

--- a/src/spectramind/calibration/dark_current_correction.py
+++ b/src/spectramind/calibration/dark_current_correction.py
@@ -1,0 +1,18 @@
+"""Dark current correction utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .calibration_config import DarkConfig
+
+
+def apply_dark_correction(cube: np.ndarray, exposure_s: float, cfg: DarkConfig) -> np.ndarray:
+    """Apply dark current correction."""
+
+    if not cfg.enabled:
+        return cube
+    if cfg.method == "frame" and cfg.frame_path:
+        dark = np.load(cfg.frame_path)
+        return cube - dark
+    return cube - (cfg.dark_rate_e_per_s * exposure_s)

--- a/src/spectramind/calibration/flat_field_correction.py
+++ b/src/spectramind/calibration/flat_field_correction.py
@@ -1,0 +1,20 @@
+"""Flat-field correction."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .calibration_config import FlatConfig
+
+
+def apply_flat_field(cube: np.ndarray, cfg: FlatConfig) -> np.ndarray:
+    """Apply flat-field correction by dividing by a flat frame or median estimate."""
+
+    if not cfg.enabled:
+        return cube
+    if cfg.frame_path is None:
+        flat = np.median(cube, axis=0)
+    else:
+        flat = np.load(cfg.frame_path)
+    denom = np.where(np.abs(flat) < cfg.eps, cfg.eps, flat)
+    return cube / denom

--- a/src/spectramind/calibration/git_env_capture.py
+++ b/src/spectramind/calibration/git_env_capture.py
@@ -1,0 +1,78 @@
+"""Git & environment capture for reproducibility metadata."""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class GitInfo:
+    branch: str = ""
+    commit: str = ""
+    is_dirty: bool = False
+    remote_url: str = ""
+
+
+@dataclass
+class EnvInfo:
+    python: str = sys.version.replace("\n", " ")
+    platform: str = platform.platform()
+    cuda: str = ""
+    torch: str = ""
+    numpy: str = ""
+
+
+def _run_cmd(cmd: str) -> str:
+    try:
+        out = subprocess.check_output(
+            cmd, shell=True, stderr=subprocess.STDOUT, text=True, timeout=3
+        )
+        return out.strip()
+    except Exception:
+        return ""
+
+
+def get_git_info() -> GitInfo:
+    branch = _run_cmd("git rev-parse --abbrev-ref HEAD")
+    commit = _run_cmd("git rev-parse HEAD")
+    status = _run_cmd("git status --porcelain")
+    remote = _run_cmd("git remote get-url origin")
+    return GitInfo(branch=branch, commit=commit, is_dirty=(status != ""), remote_url=remote)
+
+
+def get_env_info() -> EnvInfo:
+    cuda = os.getenv("CUDA_VERSION", "")
+    torch_v = ""
+    try:
+        import torch  # type: ignore
+
+        torch_v = torch.__version__
+        if not cuda:
+            cuda = getattr(torch.version, "cuda", "")
+    except Exception:
+        pass
+    numpy_v = ""
+    try:
+        import numpy as np  # type: ignore
+
+        numpy_v = np.__version__
+    except Exception:
+        pass
+    return EnvInfo(cuda=cuda, torch=torch_v, numpy=numpy_v)
+
+
+def reproducibility_snapshot(extra: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    snap: Dict[str, Any] = {
+        "git": asdict(get_git_info()),
+        "env": asdict(get_env_info()),
+        "cwd": os.getcwd(),
+        "pid": os.getpid(),
+    }
+    if extra:
+        snap.update(extra)
+    return snap

--- a/src/spectramind/calibration/jitter_injection.py
+++ b/src/spectramind/calibration/jitter_injection.py
@@ -1,0 +1,33 @@
+"""Sub-pixel jitter injection for augmentation."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    from scipy.ndimage import shift as imshift  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    def imshift(arr: np.ndarray, shift, order=1, mode="nearest") -> np.ndarray:  # type: ignore
+        if isinstance(shift, (tuple, list, np.ndarray)):
+            s = [int(round(v)) for v in shift]
+        else:
+            s = [int(round(shift)), 0, 0]
+        return np.roll(arr, shift=s, axis=(0, 1, 2))
+
+from .calibration_config import JitterInjectionConfig
+
+
+def inject_jitter(cube: np.ndarray, cfg: JitterInjectionConfig) -> tuple[np.ndarray, np.ndarray]:
+    """Inject random sub-pixel jitter along spatial axes."""
+
+    if not cfg.enabled:
+        return cube, np.zeros((cube.shape[0], 2), dtype=np.float32)
+
+    rng = np.random.default_rng(cfg.seed)
+    T = cube.shape[0]
+    shifts = rng.normal(0.0, cfg.std_px, size=(T, 2)).astype(np.float32)
+    out = np.empty_like(cube)
+    for t in range(T):
+        dy, dx = float(shifts[t, 0]), float(shifts[t, 1])
+        out[t] = imshift(cube[t], shift=(dy, dx, 0), order=1, mode="nearest")
+    return out, shifts

--- a/src/spectramind/calibration/logging_utils.py
+++ b/src/spectramind/calibration/logging_utils.py
@@ -1,0 +1,104 @@
+"""Centralised logging utilities for the calibration package.
+
+Provides console + rotating file handlers and a JSONL event stream hook.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+DEFAULT_LOG_DIR = Path(os.getenv("SPECTRAMIND_LOG_DIR", "logs"))
+DEFAULT_LOG_DIR.mkdir(parents=True, exist_ok=True)
+DEFAULT_LOG_FILE = DEFAULT_LOG_DIR / "calibration.log"
+DEFAULT_JSONL_FILE = DEFAULT_LOG_DIR / "calibration_events.jsonl"
+DEFAULT_DEBUG_MD = DEFAULT_LOG_DIR / "v50_debug_log.md"
+
+
+@dataclass
+class LogConfig:
+    """Configuration for :func:`setup_logging`."""
+
+    name: str = "spectramind.calibration"
+    level: int = logging.INFO
+    file_path: Path = DEFAULT_LOG_FILE
+    max_bytes: int = 5_000_000
+    backup_count: int = 5
+    jsonl_path: Path = DEFAULT_JSONL_FILE
+    debug_md_path: Path = DEFAULT_DEBUG_MD
+
+
+class JSONLEventLogger:
+    """Minimal JSONL logger used for diagnostics."""
+
+    def __init__(self, path: Path):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._fh = open(self.path, "a", encoding="utf-8")
+
+    def log(self, event: Dict[str, Any]) -> None:
+        self._fh.write(json.dumps(event, ensure_ascii=False) + "\n")
+        self._fh.flush()
+
+    def close(self) -> None:
+        try:
+            self._fh.close()
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
+def setup_logging(cfg: Optional[LogConfig] = None) -> Tuple[logging.Logger, JSONLEventLogger]:
+    """Create a logger and JSONL event logger."""
+
+    cfg = cfg or LogConfig()
+    logger = logging.getLogger(cfg.name)
+    logger.setLevel(cfg.level)
+    logger.propagate = False
+
+    if not logger.handlers:
+        # Console handler
+        console = logging.StreamHandler(sys.stdout)
+        console.setLevel(cfg.level)
+        console.setFormatter(
+            logging.Formatter(
+                fmt="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+        logger.addHandler(console)
+
+        # Rotating file handler
+        file_handler = RotatingFileHandler(
+            filename=str(cfg.file_path),
+            maxBytes=cfg.max_bytes,
+            backupCount=cfg.backup_count,
+            encoding="utf-8",
+        )
+        file_handler.setLevel(cfg.level)
+        file_handler.setFormatter(
+            logging.Formatter(
+                fmt="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
+                datefmt="%Y-%m-%d %H:%M:%S",
+            )
+        )
+        logger.addHandler(file_handler)
+
+    # JSONL event stream
+    evt = JSONLEventLogger(cfg.jsonl_path)
+    return logger, evt
+
+
+def append_debug_md(header: str, details: Dict[str, Any], path: Path = DEFAULT_DEBUG_MD) -> None:
+    """Append a diagnostic block to ``v50_debug_log.md``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(f"\n\n## {header}\n\n")
+        for k, v in details.items():
+            f.write(f"- {k}: {v}\n")

--- a/src/spectramind/calibration/nonlinearity_correction.py
+++ b/src/spectramind/calibration/nonlinearity_correction.py
@@ -1,0 +1,23 @@
+"""Polynomial non-linearity correction."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .calibration_config import NonlinearityConfig
+
+
+def apply_nonlinearity_correction(cube: np.ndarray, cfg: NonlinearityConfig) -> np.ndarray:
+    """Apply a polynomial correction with a single Newton step approximation."""
+
+    if not cfg.enabled:
+        return cube
+
+    coeffs = np.array(cfg.coeffs, dtype=np.float32)
+    y = np.polyval(coeffs[::-1], cube)
+
+    dcoeffs = np.polyder(coeffs[::-1])
+    dy = np.polyval(dcoeffs, y)
+    dy = np.where(np.abs(dy) < 1e-6, 1.0, dy)
+    x_est = y / dy
+    return x_est.astype(cube.dtype, copy=False)

--- a/src/spectramind/calibration/phase_normalization.py
+++ b/src/spectramind/calibration/phase_normalization.py
@@ -1,0 +1,39 @@
+"""Light-curve normalisation routines."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .calibration_config import NormalizationConfig
+
+
+def phase_normalize(flux: np.ndarray, cfg: NormalizationConfig) -> tuple[np.ndarray, dict]:
+    """Normalize light curve to ~1 outside transit."""
+
+    if not cfg.enabled:
+        return flux, {"method": "none"}
+
+    f = flux.astype(np.float64)
+    if cfg.method == "median-oot":
+        ql, qu = np.quantile(f, [0.1, 0.9])
+        oot_mask = (f >= ql) & (f <= qu)
+        baseline = np.median(f[oot_mask])
+        norm = f if baseline == 0.0 else f / baseline
+        return norm, {
+            "method": "median-oot",
+            "baseline": float(baseline),
+            "oot_count": int(oot_mask.sum()),
+        }
+
+    x = np.linspace(-1, 1, f.shape[0])
+    A = np.vstack([x ** k for k in range(cfg.poly_order + 1)]).T
+    w = np.ones_like(f)
+    for _ in range(3):
+        coeff, *_ = np.linalg.lstsq(A * w[:, None], f * w, rcond=None)
+        base = A @ coeff
+        resid = f - base
+        s = 1.4826 * np.median(np.abs(resid)) + 1e-9
+        w = (np.abs(resid) < 3 * s).astype(np.float64)
+        base = A @ coeff
+    norm = f if np.all(base == 0.0) else f / base
+    return norm, {"method": "poly", "coeff": coeff.tolist()}

--- a/src/spectramind/calibration/photometric_extraction.py
+++ b/src/spectramind/calibration/photometric_extraction.py
@@ -1,0 +1,63 @@
+"""Photometric extraction routines."""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .calibration_config import PhotometryConfig
+
+
+def _circular_mask(h: int, w: int, cx: float, cy: float, r: float) -> NDArray[np.bool_]:
+    y, x = np.ogrid[:h, :w]
+    return (x - cx) ** 2 + (y - cy) ** 2 <= r ** 2
+
+
+def aperture_photometry(
+    cube: NDArray[np.floating], cfg: PhotometryConfig
+) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
+    """Simple circular aperture photometry with background annulus."""
+
+    T, H, W = cube.shape
+    cx, cy = W / 2.0, H / 2.0
+    r = cfg.aperture_radius_px
+    mask_ap = _circular_mask(H, W, cx, cy, r)
+    mask_bg = _circular_mask(H, W, cx, cy, cfg.background_outer_px) & (~_circular_mask(H, W, cx, cy, cfg.background_inner_px))
+    ap_area = np.clip(mask_ap.sum(), 1, None)
+    bg_area = np.clip(mask_bg.sum(), 1, None)
+
+    flux = np.empty(T, dtype=np.float64)
+    err = np.empty(T, dtype=np.float64)
+    for t in range(T):
+        frame = cube[t]
+        bg = frame[mask_bg].mean() if bg_area > 0 else 0.0
+        signal = frame[mask_ap].sum() - bg * ap_area
+        flux[t] = signal
+        err[t] = np.sqrt(np.maximum(frame[mask_ap].sum(), 1.0))
+    return flux, err
+
+
+def optimal_photometry(
+    cube: NDArray[np.floating], cfg: PhotometryConfig
+) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
+    """Toy optimal photometry weighted by a Gaussian PSF."""
+
+    T, H, W = cube.shape
+    y, x = np.mgrid[0:H, 0:W]
+    cx, cy = W / 2.0, H / 2.0
+    sigma = cfg.aperture_radius_px / 2.0
+    psf = np.exp(-((x - cx) ** 2 + (y - cy) ** 2) / (2 * sigma * sigma))
+    psf /= psf.sum() + 1e-12
+    flux = (cube * psf).reshape(T, -1).sum(axis=1)
+    err = np.sqrt(np.maximum(cube.reshape(T, -1).sum(axis=1), 1.0))
+    return flux, err
+
+
+def extract_photometry(
+    cube: NDArray[np.floating], cfg: PhotometryConfig
+) -> tuple[NDArray[np.floating], NDArray[np.floating]]:
+    """Dispatch photometric extraction method."""
+
+    if cfg.method == "aperture":
+        return aperture_photometry(cube, cfg)
+    return optimal_photometry(cube, cfg)

--- a/src/spectramind/calibration/pipeline.py
+++ b/src/spectramind/calibration/pipeline.py
@@ -1,0 +1,178 @@
+"""Calibration pipeline orchestrating the full kill-chain."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from .adc_correction import apply_adc_correction
+from .calibration_config import CalibrationConfig
+from .cosmic_ray_removal import remove_cosmics_sigma_clip
+from .dark_current_correction import apply_dark_correction
+from .flat_field_correction import apply_flat_field
+from .git_env_capture import reproducibility_snapshot
+from .jitter_injection import inject_jitter
+from .logging_utils import append_debug_md, setup_logging
+from .nonlinearity_correction import apply_nonlinearity_correction
+from .phase_normalization import phase_normalize
+from .photometric_extraction import extract_photometry
+from .symbolic_calibration import apply_symbolic_constraints
+from .trace_alignment import align_spectral_traces
+
+
+def _ensure_dir(p: str | Path) -> Path:
+    p = Path(p)
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+class Calibrator:
+    """Orchestrates the calibration kill-chain for a time cube ``(T, H, W)``."""
+
+    def __init__(self, cfg: CalibrationConfig, logger=None, evt=None):
+        self.cfg = cfg
+        self.logger, self.evt = (logger, evt) if logger and evt else setup_logging()
+        self.out_dir = _ensure_dir(self.cfg.io.output_dir)
+
+    def _log_event(self, name: str, payload: Dict[str, Any]) -> None:
+        payload = dict(payload)
+        payload["event"] = name
+        self.evt.log(payload)
+        self.logger.info(
+            f"{name}: {{" + ", ".join(f"{k}={v}" for k, v in payload.items() if k != 'event') + "}}"
+        )
+
+    def run_cube(
+        self, cube: np.ndarray, exposure_s: float = 1.0, instrument: str = "AIRS"
+    ) -> Dict[str, Any]:
+        """Run full calibration on a data cube."""
+
+        cube0 = cube
+        cube, jitter = inject_jitter(cube, self.cfg.jitter)
+        self._log_event(
+            "jitter_injection",
+            {
+                "enabled": self.cfg.jitter.enabled,
+                "mean_shift": float(np.mean(jitter)) if jitter.size else 0.0,
+            },
+        )
+
+        cube = apply_adc_correction(cube, self.cfg.adc)
+        cube = apply_nonlinearity_correction(cube, self.cfg.nonlin)
+        cube = apply_dark_correction(cube, exposure_s, self.cfg.dark)
+        cube = apply_flat_field(cube, self.cfg.flat)
+        cube, cr_mask = remove_cosmics_sigma_clip(cube, self.cfg.cosmic)
+        self._log_event("cosmic_ray", {"replaced": int(cr_mask.sum())})
+
+        cube, shifts = align_spectral_traces(cube, self.cfg.align)
+        self._log_event(
+            "alignment", {"mean_shift": float(np.mean(np.abs(shifts)))}
+        )
+
+        flux, flux_err = extract_photometry(cube, self.cfg.photometry)
+        flux_norm, meta_norm = phase_normalize(flux, self.cfg.norm)
+        self._log_event("normalization", meta_norm)
+
+        axis_map = {"time": 0, "wavelength": 2}
+        cube_sym, sym_meta = apply_symbolic_constraints(
+            cube, self.cfg.symbolic, axis_map=axis_map
+        )
+        self._log_event("symbolic_calibration", sym_meta)
+
+        np.save(self.out_dir / f"{instrument}_cube_input.npy", cube0)
+        np.save(self.out_dir / f"{instrument}_cube_calibrated.npy", cube_sym)
+        np.save(self.out_dir / f"{instrument}_flux.npy", flux_norm)
+        np.save(self.out_dir / f"{instrument}_flux_err.npy", flux_err)
+
+        return {
+            "instrument": instrument,
+            "flux": flux_norm,
+            "flux_err": flux_err,
+            "cube_calibrated": cube_sym,
+            "shifts": shifts,
+            "cr_replaced": int(cr_mask.sum()),
+            "norm_meta": meta_norm,
+            "sym_meta": sym_meta,
+        }
+
+    def save_run_manifest(self, meta: Dict[str, Any], name: str = "calibration_run.json") -> Path:
+        p = self.out_dir / name
+        with open(p, "w", encoding="utf-8") as f:
+            json.dump(meta, f, indent=2)
+        return p
+
+
+def run_calibration_one(
+    cube_path: str,
+    instrument: str,
+    cfg: Optional[CalibrationConfig] = None,
+    exposure_s: float = 1.0,
+) -> Dict[str, Any]:
+    cfg = cfg or CalibrationConfig()
+    logger, evt = setup_logging()
+    append_debug_md(
+        "Calibration Start",
+        {
+            "instrument": instrument,
+            "cube_path": cube_path,
+            "output_dir": cfg.io.output_dir,
+        },
+    )
+    cal = Calibrator(cfg, logger=logger, evt=evt)
+    cube = np.load(cube_path)
+    result = cal.run_cube(cube, exposure_s=exposure_s, instrument=instrument)
+    manifest = {
+        "config": cfg.to_dict(),
+        "snapshot": reproducibility_snapshot(),
+        "instrument": instrument,
+        "cube_path": cube_path,
+        "outputs": {
+            "flux": str(Path(cfg.io.output_dir) / f"{instrument}_flux.npy"),
+            "flux_err": str(Path(cfg.io.output_dir) / f"{instrument}_flux_err.npy"),
+            "cube_calibrated": str(
+                Path(cfg.io.output_dir) / f"{instrument}_cube_calibrated.npy"
+            ),
+        },
+        "stats": {
+            "cr_replaced": result.get("cr_replaced", 0),
+            "mean_shift": float(np.mean(np.abs(result.get("shifts", np.array([0]))))),
+        },
+    }
+    cal.save_run_manifest(manifest)
+    return result
+
+
+def run_calibration_batch(
+    input_dir: str,
+    cfg: Optional[CalibrationConfig] = None,
+    exposure_s: float = 1.0,
+) -> Dict[str, Any]:
+    cfg = cfg or CalibrationConfig()
+    logger, evt = setup_logging()
+    append_debug_md(
+        "Calibration Batch Start",
+        {
+            "input_dir": input_dir,
+            "output_dir": cfg.io.output_dir,
+        },
+    )
+    cal = Calibrator(cfg, logger=logger, evt=evt)
+    paths = list(Path(input_dir).glob("*.npy"))
+    runs = []
+    for p in paths:
+        name = p.stem
+        inst = "AIRS" if "AIRS" in name.upper() else ("FGS1" if "FGS" in name.upper() else "UNK")
+        cube = np.load(p)
+        res = cal.run_cube(cube, exposure_s=exposure_s, instrument=inst)
+        runs.append({"path": str(p), "instrument": inst, "cr_replaced": res.get("cr_replaced", 0)})
+    manifest = {
+        "config": cfg.to_dict(),
+        "snapshot": reproducibility_snapshot(),
+        "batch": runs,
+    }
+    cal.save_run_manifest(manifest, name="calibration_batch.json")
+    return manifest

--- a/src/spectramind/calibration/symbolic_calibration.py
+++ b/src/spectramind/calibration/symbolic_calibration.py
@@ -1,0 +1,43 @@
+"""Symbolic calibration enforcing simple constraints."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    from scipy.ndimage import uniform_filter1d  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    def uniform_filter1d(a, size, axis, mode="nearest"):
+        kernel = np.ones(size) / size
+        return np.apply_along_axis(lambda m: np.convolve(m, kernel, mode="same"), axis, a)
+
+from .calibration_config import SymbolicCalibrationConfig
+
+
+def apply_symbolic_constraints(
+    cube: np.ndarray,
+    cfg: SymbolicCalibrationConfig,
+    axis_map: dict[str, int] | None = None,
+) -> tuple[np.ndarray, dict]:
+    """Apply simple physics-informed constraints."""
+
+    if not cfg.enabled:
+        return cube, {"enabled": False}
+
+    out = cube.copy()
+    meta: dict[str, int | str] = {}
+
+    if cfg.nonnegativity:
+        neg_count = int((out < 0).sum())
+        out = np.maximum(out, 0.0)
+        meta["negatives_clipped"] = neg_count
+
+    if cfg.smooth_window > 1:
+        ax = 2
+        if axis_map and cfg.smooth_axis in axis_map:
+            ax = axis_map[cfg.smooth_axis]
+        out = uniform_filter1d(out, size=cfg.smooth_window, axis=ax, mode="nearest")
+        meta["smooth_window"] = cfg.smooth_window
+        meta["smooth_axis"] = cfg.smooth_axis
+
+    return out, meta

--- a/src/spectramind/calibration/temperature_scaling.py
+++ b/src/spectramind/calibration/temperature_scaling.py
@@ -1,0 +1,19 @@
+"""Temperature scaling utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def fit_temperature_scaling(residuals: np.ndarray, sigma_pred: np.ndarray) -> float:
+    """Fit global temperature scaling parameter T."""
+
+    std_r = float(np.std(residuals))
+    mean_s = float(np.mean(np.abs(sigma_pred)) + 1e-12)
+    return std_r / mean_s
+
+
+def apply_temperature_scaling(sigma_pred: np.ndarray, T: float) -> np.ndarray:
+    """Apply temperature scaling to predicted sigma."""
+
+    return sigma_pred * T

--- a/src/spectramind/calibration/trace_alignment.py
+++ b/src/spectramind/calibration/trace_alignment.py
@@ -1,0 +1,53 @@
+"""Spectral trace alignment utilities."""
+
+from __future__ import annotations
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    from scipy.ndimage import shift as imshift  # type: ignore
+except Exception:  # pragma: no cover - fallback
+    def imshift(arr: np.ndarray, shift, order=1, mode="nearest") -> np.ndarray:  # type: ignore
+        """Fallback implementation using ``np.roll`` when SciPy is unavailable."""
+
+        if isinstance(shift, (tuple, list, np.ndarray)):
+            s = [int(round(v)) for v in shift]
+        else:
+            s = [0, 0, int(round(shift))]
+        return np.roll(arr, shift=s, axis=(0, 1, 2))
+
+from .calibration_config import AlignmentConfig
+
+
+def estimate_shift_1d(a: np.ndarray, b: np.ndarray, max_shift: int) -> float:
+    """Estimate shift between 1D arrays using cross-correlation."""
+
+    a = (a - a.mean()) / (a.std() + 1e-8)
+    b = (b - b.mean()) / (b.std() + 1e-8)
+    best_s, best_c = 0, -1e9
+    for s in range(-max_shift, max_shift + 1):
+        c = np.dot(a[max(0, s) : len(a) + min(0, s)], b[max(0, -s) : len(b) + min(0, -s)])
+        if c > best_c:
+            best_c, best_s = c, s
+    return float(best_s)
+
+
+def align_spectral_traces(cube: np.ndarray, cfg: AlignmentConfig) -> tuple[np.ndarray, np.ndarray]:
+    """Align along the spectral axis (axis 2)."""
+
+    if not cfg.enabled:
+        return cube, np.zeros(cube.shape[0], dtype=np.float32)
+
+    T, H, W = cube.shape
+    ref = cube[0]
+    shifts = np.zeros(T, dtype=np.float32)
+    out = np.empty_like(cube)
+    out[0] = ref
+    for t in range(1, T):
+        s = estimate_shift_1d(ref.mean(axis=0), cube[t].mean(axis=0), cfg.max_shift_px)
+        shifts[t] = s
+        if cfg.subpixel:
+            out[t] = imshift(cube[t], shift=(0, 0, -s), order=1, mode="nearest")
+        else:
+            out[t] = np.roll(cube[t], shift=int(-s), axis=2)
+    return out, shifts


### PR DESCRIPTION
## Summary
- add calibration pipeline orchestrating ADC, dark, flat-field, alignment, photometry, normalization and symbolic constraints
- include Typer CLI for running single or batch calibrations and sigma calibration utilities
- provide logging utilities with rotating file handler and JSONL event stream

## Testing
- `PYTHONPATH=. pytest tests/test_fusion.py::test_factory_and_forward_all -q` *(fails: FGS1 latent D mismatch expected 256, got 32)*

------
https://chatgpt.com/codex/tasks/task_e_689f34883a94832a99a753d85529d810