### PR TITLE
Add SpectraMind V50 config system with schema validation

### DIFF
--- a/src/spectramind/config/README.md
+++ b/src/spectramind/config/README.md
@@ -1,0 +1,64 @@
+# SpectraMind V50 Config System
+
+Mission-grade configuration layer for the SpectraMind V50 pipeline.
+
+## What you get
+
+- **Schema-enforced** YAML/JSON configs (`config_schema.yaml`, `config_validator.py`)
+- **Hydra/OmegaConf compatible** overrides (`load_hydra_config`, `hydra_overrides.yaml`)
+- **Auto-registration on import**:
+  - `defaults` → `defaults.yaml`
+  - `v50` → `config_v50.yaml`
+- **Global registry** (`registry.py`) available as `spectramind.config.CONFIG_REGISTRY`
+- **Environment helpers** (`env.py`) with CUDA-aware device detection
+
+## Quick start
+
+Importing the package auto-registers configs:
+
+```python
+from spectramind.config import CONFIG_REGISTRY, get_config  # get_config via registry if you import it
+# Access auto-registered configs
+v50 = CONFIG_REGISTRY["v50"]
+defaults = CONFIG_REGISTRY["defaults"]
+```
+
+Programmatic load + validation from a custom path:
+
+```python
+from spectramind.config import load_config
+cfg = load_config("path/to/your_config.yaml")
+```
+
+Hydra/OmegaConf-style build from overrides:
+
+```python
+from spectramind.config import load_hydra_config
+cfg = load_hydra_config({"training": {"epochs": 100, "batch_size": 64}})
+```
+
+## CLI/Hydra tip
+
+You can pass overrides when launching your scripts (if they parse OmegaConf/Hydra inputs):
+
+```bash
+python train_v50.py model.encoder=fgs1_mamba training.epochs=100
+```
+
+## Validation
+
+All loads validate against `config_schema.yaml` using `jsonschema`. Install:
+
+```bash
+pip install jsonschema pyyaml omegaconf
+# (hydra-core optional for full Hydra workflows)
+```
+
+## Silence import logs
+
+Set `SPECTRAMIND_CONFIG_SILENT=1` to disable the one-line auto-registration message:
+
+```bash
+export SPECTRAMIND_CONFIG_SILENT=1
+```
+

--- a/src/spectramind/config/__init__.py
+++ b/src/spectramind/config/__init__.py
@@ -1,0 +1,78 @@
+"""
+SpectraMind V50 Config Package
+Provides loading, validation, registry utilities, and auto-registration of default configs.
+
+Master-programmer features:
+- On import, automatically registers:
+  - 'defaults' from defaults.yaml
+  - 'v50' from config_v50.yaml
+- Safe, idempotent, Hydra-compatible, schema-validated.
+- Logs lightweight status to stdout only on first import (can be silenced via SPECTRAMIND_CONFIG_SILENT=1).
+
+Directory layout expected beside this file:
+- base_config.py, config_loader.py, config_validator.py, config_schema.yaml
+- defaults.yaml, config_v50.yaml, registry.py, hydra_overrides.yaml, env.py
+"""
+
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+from .base_config import BaseConfig
+from .config_loader import load_config, load_hydra_config
+from .config_validator import validate_config
+from .registry import CONFIG_REGISTRY, register_config
+
+__all__ = [
+    "BaseConfig",
+    "load_config",
+    "load_hydra_config",
+    "validate_config",
+    "CONFIG_REGISTRY",
+    "register_config",
+]
+
+# ---- Auto-registration on import -------------------------------------------------
+
+def _maybe_print(msg: str) -> None:
+    # Respect a simple env toggle to silence messages in CI/production
+    if os.environ.get("SPECTRAMIND_CONFIG_SILENT", "0") not in ("1", "true", "True"):
+        print(msg)
+
+def _safe_register(name: str, cfg: Dict[str, Any]) -> None:
+    # Idempotent registration (won't overwrite an existing key)
+    if name not in CONFIG_REGISTRY:
+        register_config(name, cfg)
+
+def _load_local_yaml(rel_filename: str) -> Dict[str, Any]:
+    # Load a YAML config located next to this package, with schema validation
+    here = Path(__file__).parent
+    cfg_path = here / rel_filename
+    if not cfg_path.exists():
+        raise FileNotFoundError(f"[spectramind.config] Missing expected file: {cfg_path}")
+    cfg = load_config(str(cfg_path))
+    return cfg
+
+def _auto_register_defaults() -> None:
+    try:
+        defaults_cfg = _load_local_yaml("defaults.yaml")
+        _safe_register("defaults", defaults_cfg)
+    except Exception as e:
+        _maybe_print(f"[spectramind.config] defaults auto-register skipped: {e}")
+
+def _auto_register_v50() -> None:
+    try:
+        v50_cfg = _load_local_yaml("config_v50.yaml")
+        _safe_register("v50", v50_cfg)
+    except Exception as e:
+        _maybe_print(f"[spectramind.config] v50 auto-register skipped: {e}")
+
+# Perform auto-registration once per interpreter session
+try:
+    _auto_register_defaults()
+    _auto_register_v50()
+    _maybe_print("[spectramind.config] Auto-registered configs: "
+                 + ", ".join(sorted(list(CONFIG_REGISTRY.keys()))))
+except Exception as _e:
+    _maybe_print(f"[spectramind.config] Auto-registration encountered an issue: {_e}")

--- a/src/spectramind/config/base_config.py
+++ b/src/spectramind/config/base_config.py
@@ -1,0 +1,16 @@
+"""
+BaseConfig definition for SpectraMind V50.
+Supports nested dataclasses for model, training, calibration, diagnostics, symbolic, and env configs.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+@dataclass
+class BaseConfig:
+    model: Dict[str, Any] = field(default_factory=dict)
+    training: Dict[str, Any] = field(default_factory=dict)
+    calibration: Dict[str, Any] = field(default_factory=dict)
+    diagnostics: Dict[str, Any] = field(default_factory=dict)
+    symbolic: Dict[str, Any] = field(default_factory=dict)
+    env: Dict[str, Any] = field(default_factory=dict)

--- a/src/spectramind/config/config_loader.py
+++ b/src/spectramind/config/config_loader.py
@@ -1,0 +1,63 @@
+"""
+YAML/JSON config loader with Hydra/OmegaConf support and schema validation.
+
+Features:
+- load_config(path): Load YAML/JSON and validate against config_schema.yaml
+- load_hydra_config(overrides): Create an OmegaConf from dict overrides (Hydra-style), validate, and return dict
+"""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+from .config_validator import validate_config
+
+def load_config(path: str) -> Dict[str, Any]:
+    """
+    Load a YAML or JSON configuration file and validate it.
+
+    Args:
+        path: Path to a .yaml/.yml or .json file.
+
+    Returns:
+        Dict[str, Any]: The validated configuration dictionary.
+
+    Raises:
+        FileNotFoundError: If path does not exist.
+        ValueError: If file extension unsupported or schema validation fails.
+    """
+    path_obj = Path(path)
+    if not path_obj.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    with open(path_obj, "r") as f:
+        if path_obj.suffix in (".yaml", ".yml"):
+            cfg = yaml.safe_load(f) or {}
+        elif path_obj.suffix == ".json":
+            cfg = json.load(f)
+        else:
+            raise ValueError(f"Unsupported config format: {path_obj.suffix}")
+    validate_config(cfg)
+    return cfg
+
+def load_hydra_config(overrides: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Create an OmegaConf/Hydra-style configuration from a dict of overrides, validate it, and return as a plain dict.
+
+    Note:
+      - This does NOT launch a Hydra job; it only builds an in-memory config for convenience.
+      - If Hydra/OmegaConf are not installed, import will fail; install via `pip install hydra-core omegaconf`.
+
+    Args:
+        overrides: Dict[str, Any] of nested keys/values (e.g., {"training": {"epochs": 100}})
+
+    Returns:
+        Dict[str, Any]: Resolved plain dict after validation.
+    """
+    from omegaconf import OmegaConf
+    cfg = OmegaConf.create(overrides or {})
+    resolved = OmegaConf.to_container(cfg, resolve=True)  # type: ignore[arg-type]
+    validate_config(resolved)  # type: ignore[arg-type]
+    return resolved  # type: ignore[return-value]

--- a/src/spectramind/config/config_schema.yaml
+++ b/src/spectramind/config/config_schema.yaml
@@ -1,0 +1,140 @@
+$schema: "http://json-schema.org/draft-07/schema#"
+title: "SpectraMind V50 Configuration Schema"
+type: object
+properties:
+  model:
+    type: object
+    properties:
+      encoder:
+        type: string
+        description: "Name of primary encoder module (e.g., 'fgs1_mamba')."
+      encoder_params:
+        type: object
+        description: "Hyperparameters for encoder."
+      airs_gnn:
+        type: object
+        description: "AIRS spectral GNN configuration (e.g., GAT with edge features)."
+        properties:
+          type:
+            type: string
+          heads:
+            type: integer
+            minimum: 1
+          hidden_dim:
+            type: integer
+            minimum: 1
+          edge_features:
+            type: boolean
+        additionalProperties: true
+      decoder:
+        type: string
+        description: "Decoder name (e.g., 'multi_scale_decoder')."
+      decoder_params:
+        type: object
+        description: "Parameters for mu/sigma decoders and fusion heads."
+      params:
+        type: object
+        description: "Generic legacy params block (optional; kept for backward compatibility)."
+    required: ["encoder", "decoder"]
+    additionalProperties: true
+
+  training:
+    type: object
+    properties:
+      epochs:
+        type: integer
+        minimum: 1
+      batch_size:
+        type: integer
+        minimum: 1
+      lr:
+        type: number
+        minimum: 0
+      optimizer:
+        type: string
+      weight_decay:
+        type: number
+        minimum: 0
+      amp:
+        type: boolean
+      scheduler:
+        type: object
+        properties:
+          type:
+            type: string
+          warmup_epochs:
+            type: integer
+            minimum: 0
+        additionalProperties: true
+      gradient_accumulation_steps:
+        type: integer
+        minimum: 1
+      save_every:
+        type: integer
+        minimum: 1
+      log_every:
+        type: integer
+        minimum: 1
+      curriculum:
+        type: object
+        properties:
+          mae_pretrain: {type: boolean}
+          contrastive: {type: boolean}
+          symbolic_finetune: {type: boolean}
+        additionalProperties: true
+    required: ["epochs", "batch_size"]
+    additionalProperties: true
+
+  calibration:
+    type: object
+    properties:
+      method:
+        type: string
+      corel_params:
+        type: object
+        properties:
+          edge_features: {type: boolean}
+          temporal_bin_encoding: {type: string}
+          coverage_target:
+            type: number
+            minimum: 0
+            maximum: 1
+          symbolic_weighting: {type: boolean}
+        additionalProperties: true
+    additionalProperties: true
+
+  diagnostics:
+    type: object
+    properties:
+      run_gll: {type: boolean}
+      run_fft: {type: boolean}
+      run_shap: {type: boolean}
+      run_symbolic_overlay: {type: boolean}
+      run_umap: {type: boolean}
+      run_tsne: {type: boolean}
+      html_report: {type: boolean}
+    additionalProperties: true
+
+  symbolic:
+    type: object
+    properties:
+      enable_constraints: {type: boolean}
+      constraints:
+        type: object
+        properties:
+          smoothness_weight: {type: number, minimum: 0}
+          asymmetry_weight: {type: number, minimum: 0}
+          nonnegativity_weight: {type: number, minimum: 0}
+          photonic_alignment_weight: {type: number, minimum: 0}
+        additionalProperties: true
+    additionalProperties: true
+
+  env:
+    type: object
+    properties:
+      device: {type: string}
+      num_workers: {type: integer, minimum: 0}
+    additionalProperties: true
+
+required: ["model", "training"]
+additionalProperties: true

--- a/src/spectramind/config/config_v50.yaml
+++ b/src/spectramind/config/config_v50.yaml
@@ -1,0 +1,66 @@
+# Hydra-ready canonical SpectraMind V50 configuration.
+# Physics-informed, neuro-symbolic, challenge-grade defaults.
+model:
+  encoder: "fgs1_mamba"
+  encoder_params:
+    hidden_dim: 256
+    depth: 12
+    dropout: 0.1
+  airs_gnn:
+    type: "gat"
+    heads: 4
+    hidden_dim: 256
+    edge_features: true
+  decoder: "multi_scale_decoder"
+  decoder_params:
+    output_bins: 283
+    dropout: 0.05
+    uncertainty_head: "flow_uncertainty"
+    use_attention_fusion: true
+
+training:
+  epochs: 50
+  batch_size: 64
+  lr: 0.0005
+  optimizer: "adamw"
+  weight_decay: 0.01
+  amp: true
+  scheduler:
+    type: "cosine"
+    warmup_epochs: 5
+  gradient_accumulation_steps: 2
+  save_every: 5
+  log_every: 50
+  curriculum:
+    mae_pretrain: true
+    contrastive: true
+    symbolic_finetune: true
+
+calibration:
+  method: "corel"
+  corel_params:
+    edge_features: true
+    temporal_bin_encoding: "fourier"
+    coverage_target: 0.9
+    symbolic_weighting: true
+
+diagnostics:
+  run_gll: true
+  run_fft: true
+  run_shap: true
+  run_symbolic_overlay: true
+  run_umap: true
+  run_tsne: true
+  html_report: true
+
+symbolic:
+  enable_constraints: true
+  constraints:
+    smoothness_weight: 0.2
+    asymmetry_weight: 0.1
+    nonnegativity_weight: 0.05
+    photonic_alignment_weight: 0.15
+
+env:
+  device: "cuda"
+  num_workers: 8

--- a/src/spectramind/config/config_validator.py
+++ b/src/spectramind/config/config_validator.py
@@ -1,0 +1,31 @@
+"""
+Schema-based config validator for SpectraMind V50 configs.
+
+Uses jsonschema Draft-07 via a YAML schema file located next to this module.
+"""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Dict, Any
+
+import yaml
+from jsonschema import validate, ValidationError
+
+SCHEMA_PATH = Path(__file__).parent / "config_schema.yaml"
+
+def validate_config(cfg: Dict[str, Any]) -> None:
+    """
+    Validate a config dict against the local JSON schema.
+
+    Raises:
+        FileNotFoundError: If the schema file is missing.
+        ValueError: If validation fails with details.
+    """
+    if not SCHEMA_PATH.exists():
+        raise FileNotFoundError(f"Config schema not found at {SCHEMA_PATH}")
+    with open(SCHEMA_PATH, "r") as f:
+        schema = yaml.safe_load(f) or {}
+    try:
+        validate(instance=cfg, schema=schema)
+    except ValidationError as e:
+        raise ValueError(f"Invalid configuration: {e.message}") from e

--- a/src/spectramind/config/defaults.yaml
+++ b/src/spectramind/config/defaults.yaml
@@ -1,0 +1,26 @@
+# Lightweight defaults — safe, minimal baseline that passes schema validation.
+model:
+  encoder: "fgs1_mamba"
+  decoder: "multi_scale_decoder"
+  params:
+    hidden_dim: 256
+    dropout: 0.1
+
+training:
+  epochs: 10
+  batch_size: 32
+  lr: 0.001
+  optimizer: "adamw"
+
+calibration:
+  method: "corel"
+
+diagnostics:
+  run_gll: true
+  run_fft: true
+
+symbolic:
+  enable_constraints: true
+
+env:
+  device: "cuda"

--- a/src/spectramind/config/env.py
+++ b/src/spectramind/config/env.py
@@ -1,0 +1,20 @@
+"""
+Environment helpers for SpectraMind V50 config system.
+
+- get_device(): Return 'cuda' if available else 'cpu'
+- get_env_var(): Read environment variables with default
+"""
+
+import os
+
+def get_device() -> str:
+    # Deferred import to avoid requiring torch at config import time
+    try:
+        import torch  # type: ignore
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    except Exception:
+        # If torch is not installed yet, fall back to env or cpu
+        return os.environ.get("SPECTRAMIND_DEVICE", "cpu")
+
+def get_env_var(key: str, default=None):
+    return os.environ.get(key, default)

--- a/src/spectramind/config/hydra_overrides.yaml
+++ b/src/spectramind/config/hydra_overrides.yaml
@@ -1,0 +1,4 @@
+# Standard Hydra runtime overrides for local runs
+defaults:
+  - override hydra.run.dir=outputs/${now:%Y-%m-%d_%H-%M-%S}
+  - override hydra.job.chdir=True

--- a/src/spectramind/config/registry.py
+++ b/src/spectramind/config/registry.py
@@ -1,0 +1,31 @@
+"""
+Global config registry for SpectraMind V50.
+
+Simple, explicit mapping name -> config dict.
+Idempotent semantics are enforced by __init__ import hooks.
+"""
+
+from typing import Dict, Any
+
+CONFIG_REGISTRY: Dict[str, Dict[str, Any]] = {}
+
+def register_config(name: str, cfg: Dict[str, Any]) -> None:
+    """
+    Register a config dict under a unique name.
+
+    Note:
+      - Overwrites are intentionally disallowed via higher-level helpers.
+      - Use spectramind.config.register_config directly if you do want to overwrite.
+    """
+    CONFIG_REGISTRY[name] = cfg
+
+def get_config(name: str) -> Dict[str, Any]:
+    """
+    Retrieve a registered config by name.
+
+    Raises:
+        KeyError: If name not present.
+    """
+    if name not in CONFIG_REGISTRY:
+        raise KeyError(f"Config '{name}' not found in registry")
+    return CONFIG_REGISTRY[name]


### PR DESCRIPTION
## Summary
- add spectramind.config package with BaseConfig, loaders, validators, and registry
- auto-register default and v50 configs on import and provide YAML schema
- include docs and helper utilities for Hydra overrides and environment detection

## Testing
- `PYTHONPATH=. pytest` *(fails: FGS1 latent D mismatch: expected 256, got 32)*

------
https://chatgpt.com/codex/tasks/task_e_689f3d4908cc832ab8e17601a1c99baf