### PR TITLE
Add v50 inference utilities and stabilize fusion factory

### DIFF
--- a/src/spectramind/infer/__init__.py
+++ b/src/spectramind/infer/__init__.py
@@ -1,1 +1,32 @@
+# -*- coding: utf-8 -*-
+"""
+SpectraMind V50 — Inference Subsystem Package
 
+This package provides mission-grade inference, ensemble aggregation, uncertainty
+calibration, diagnostics, and packaging utilities for the NeurIPS 2025 Ariel Data
+Challenge.
+
+Exports a minimal surface for external CLIs to import without side effects.
+"""
+
+from .utils_infer import (
+    InferenceConfig,
+    ensure_run_dir,
+    setup_logging_stack,
+    compute_config_hash,
+    write_json,
+    read_json,
+    write_jsonl_event,
+    append_to_debug_log,
+)
+
+__all__ = [
+    "InferenceConfig",
+    "ensure_run_dir",
+    "setup_logging_stack",
+    "compute_config_hash",
+    "write_json",
+    "read_json",
+    "write_jsonl_event",
+    "append_to_debug_log",
+]

--- a/src/spectramind/infer/calibrate_uncertainty_v50.py
+++ b/src/spectramind/infer/calibrate_uncertainty_v50.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+"""SpectraMind V50 — Uncertainty Calibration"""
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+import torch
+
+from .utils_infer import append_to_debug_log, write_json, write_jsonl_event, InferenceConfig
+
+
+class TemperatureScaler(torch.nn.Module):
+    """Per-bin or global temperature scaling for sigma."""
+
+    def __init__(self, bins: int, per_bin: bool = True):
+        super().__init__()
+        self.bins = bins
+        self.per_bin = per_bin
+        if per_bin:
+            self.log_T = torch.nn.Parameter(torch.zeros(bins))
+        else:
+            self.log_T = torch.nn.Parameter(torch.zeros(1))
+
+    def fit(
+        self,
+        mu: torch.Tensor,
+        sigma: torch.Tensor,
+        target: torch.Tensor,
+        lr: float = 0.1,
+        steps: int = 200,
+    ) -> torch.Tensor:
+        assert mu.shape == sigma.shape == target.shape
+        opt = torch.optim.Adam([self.log_T], lr=lr)
+        for _ in range(steps):
+            opt.zero_grad()
+            T = self.temperature().view(1, -1 if self.per_bin else 1)
+            cal_sigma = torch.clamp(sigma * T, min=1e-6)
+            loss = 0.5 * torch.log(2 * torch.pi * cal_sigma ** 2) + (target - mu) ** 2 / (
+                2 * cal_sigma ** 2
+            )
+            loss = loss.mean()
+            loss.backward()
+            opt.step()
+        return self.temperature().detach()
+
+    def temperature(self) -> torch.Tensor:
+        return torch.exp(self.log_T)
+
+    def apply(self, sigma: torch.Tensor) -> torch.Tensor:
+        T = self.temperature().view(1, -1 if self.per_bin else 1)
+        return torch.clamp(sigma * T, min=1e-6)
+
+
+class CorelCalibrator:
+    """Thin wrapper to call external Spectral COREl GNN calibrator if present."""
+
+    def __init__(self, cfg: InferenceConfig):
+        self.cfg = cfg
+        self._impl = None
+        try:
+            mod = __import__("spectramind.calibration.corel", fromlist=["SpectralCOREL"])
+            self._impl = getattr(mod, "SpectralCOREL")
+        except Exception:
+            self._impl = None
+
+    def fit_predict(
+        self,
+        mu: torch.Tensor,
+        sigma: torch.Tensor,
+        target: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        logger = logging.getLogger("spectramind.infer")
+        if self._impl is None:
+            logger.warning("COREL calibrator not available; sigma passthrough.")
+            return sigma
+        try:
+            instance = self._impl(
+                cfg=self.cfg, bins=mu.shape[1], **(self.cfg.calibration.get("corel", {}))
+            )
+            return instance.fit_predict(mu=mu, sigma=sigma, y=target)
+        except Exception as e:  # pragma: no cover
+            logger.exception("COREL calibrator failed; sigma passthrough: %s", e)
+            return sigma
+
+def calibrate_predictions(
+    cfg: InferenceConfig,
+    mu: torch.Tensor,
+    sigma: torch.Tensor,
+    calib: Optional[Dict[str, torch.Tensor]],
+    out_dir: pathlib.Path,
+) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+    """Apply configured calibration steps; return calibrated (mu, sigma) and summary."""
+    logger = logging.getLogger("spectramind.infer")
+    sigma = torch.clamp(sigma, min=1e-6)
+    summary: Dict[str, Any] = {"steps": []}
+
+    tconf = cfg.calibration.get("temperature", {"enabled": True, "per_bin": True})
+    if tconf.get("enabled", True) and calib is not None and "target" in calib:
+        scaler = TemperatureScaler(
+            bins=mu.shape[1], per_bin=bool(tconf.get("per_bin", True))
+        )
+        T = scaler.fit(
+            mu=mu,
+            sigma=sigma,
+            target=calib["target"],
+            lr=float(tconf.get("lr", 0.1)),
+            steps=int(tconf.get("steps", 200)),
+        )
+        sigma = scaler.apply(sigma)
+        summary["steps"].append(
+            {
+                "kind": "temperature_scaling",
+                "per_bin": scaler.per_bin,
+                "T": T.detach().cpu().tolist(),
+            }
+        )
+        logger.info("Applied temperature scaling (per_bin=%s).", scaler.per_bin)
+    else:
+        logger.info(
+            "Temperature scaling skipped (enabled=%s, target=%s).",
+            tconf.get("enabled", True),
+            calib is not None and "target" in calib,
+        )
+
+    if cfg.calibration.get("corel", {}).get("enabled", False) and calib is not None and "target" in calib:
+        corel = CorelCalibrator(cfg)
+        sigma = corel.fit_predict(mu=mu, sigma=sigma, target=calib["target"])
+        summary["steps"].append({"kind": "corel"})
+        logger.info("Applied COREL calibration.")
+    else:
+        logger.info("COREL calibration skipped or unavailable.")
+
+    write_json(out_dir / "calibration_summary.json", summary)
+    return mu, sigma, summary

--- a/src/spectramind/infer/diagnose_infer_outputs.py
+++ b/src/spectramind/infer/diagnose_infer_outputs.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+"""SpectraMind V50 — Post-Inference Diagnostics"""
+from __future__ import annotations
+
+import logging
+import pathlib
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+
+from .utils_infer import write_json
+
+
+def compute_metrics(
+    mu: torch.Tensor,
+    sigma: torch.Tensor,
+    target: Optional[torch.Tensor] = None,
+) -> Dict[str, Any]:
+    """Compute core metrics; if target is None, return empty metrics."""
+    if target is None:
+        return {"note": "no_target", "metrics": {}}
+    mu, sigma, target = mu.detach(), torch.clamp(sigma.detach(), min=1e-6), target.detach()
+    gll = 0.5 * torch.log(2 * torch.pi * sigma ** 2) + (target - mu) ** 2 / (2 * sigma ** 2)
+    rmse = torch.sqrt(((target - mu) ** 2).mean())
+    mae = (target - mu).abs().mean()
+    z = (target - mu) / sigma
+    return {
+        "metrics": {
+            "GLL_mean": gll.mean().item(),
+            "RMSE": rmse.item(),
+            "MAE": mae.item(),
+            "z_mean": z.mean().item(),
+            "z_std": z.std(unbiased=False).item(),
+        }
+    }
+
+
+def save_diagnostics(
+    out_dir: pathlib.Path,
+    metrics: Dict[str, Any],
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    payload = dict(metrics)
+    if extra:
+        payload["extra"] = extra
+    write_json(out_dir / "diagnostics_summary.json", payload)

--- a/src/spectramind/infer/ensemble_predict_v50.py
+++ b/src/spectramind/infer/ensemble_predict_v50.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+"""SpectraMind V50 — Ensemble Prediction Aggregator"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import torch
+
+from .utils_infer import write_json
+
+
+def aggregate_ensemble(
+    preds: List[Tuple[torch.Tensor, torch.Tensor]],
+    method_mu: str = "mean",
+    method_sigma: str = "geom_mean",
+    weights: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor, Dict[str, Any]]:
+    """Aggregate predictions from K models."""
+    K = len(preds)
+    assert K >= 1, "Need at least one prediction to aggregate."
+    mus = torch.stack([p[0] for p in preds], dim=0)
+    sig = torch.stack([p[1] for p in preds], dim=0)
+
+    if weights is None:
+        w = torch.ones((K, 1, 1), dtype=mus.dtype, device=mus.device) / K
+    else:
+        w = weights
+        if w.ndim == 1:
+            w = w.view(K, 1, 1)
+        elif w.ndim == 2:
+            w = w.view(K, 1, -1)
+        w = w / (w.sum(dim=0, keepdim=True) + 1e-9)
+
+    if method_mu == "median":
+        mu_agg = mus.median(dim=0).values
+    else:
+        mu_agg = (w * mus).sum(dim=0)
+
+    if method_sigma == "mean":
+        sigma_agg = (w * sig).sum(dim=0)
+    else:
+        sigma_agg = torch.exp((w * torch.log(torch.clamp(sig, min=1e-9))).sum(dim=0))
+
+    summary = {
+        "K": K,
+        "method_mu": method_mu,
+        "method_sigma": method_sigma,
+        "weights_shape": list(w.shape),
+    }
+    return mu_agg, sigma_agg, summary

--- a/src/spectramind/infer/package_submission_v50.py
+++ b/src/spectramind/infer/package_submission_v50.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""SpectraMind V50 — Submission Packaging"""
+from __future__ import annotations
+
+import datetime
+import json
+import zipfile
+from typing import Any, Dict, Optional
+
+import pathlib
+
+from .utils_infer import capture_git_state, capture_python_env, compute_config_hash, write_json
+
+
+def build_manifest(
+    run_dir: pathlib.Path,
+    cfg_hash: str,
+    extras: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    now = datetime.datetime.now().isoformat()
+    manifest = {
+        "created": now,
+        "config_hash": cfg_hash,
+        "git": capture_git_state(),
+        "env": capture_python_env(),
+        "artifacts": sorted(
+            [str(p.relative_to(run_dir)) for p in run_dir.rglob("*") if p.is_file()]
+        ),
+    }
+    if extras:
+        manifest.update(extras)
+    write_json(run_dir / "artifacts" / "manifest.json", manifest)
+    return manifest
+
+
+def make_zip_bundle(run_dir: pathlib.Path, out_name: Optional[str] = None) -> pathlib.Path:
+    out_name = out_name or f"submission_bundle_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}.zip"
+    zip_path = run_dir / out_name
+    with zipfile.ZipFile(zip_path, "w", compression=zipfile.ZIP_DEFLATED) as z:
+        sub = run_dir / "submission" / "submission.csv"
+        if sub.exists():
+            z.write(sub, arcname=f"submission/{sub.name}")
+        for rel in [
+            "artifacts/calibration_summary.json",
+            "artifacts/diagnostics_summary.json",
+            "artifacts/manifest.json",
+        ]:
+            p = run_dir / rel
+            if p.exists():
+                z.write(p, arcname=rel)
+        for p in (run_dir / "artifacts").glob("*.html"):
+            z.write(p, arcname=f"artifacts/{p.name}")
+    return zip_path

--- a/src/spectramind/infer/predict_v50.py
+++ b/src/spectramind/infer/predict_v50.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""SpectraMind V50 — Predict Entrypoint"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import torch
+
+from .calibrate_uncertainty_v50 import calibrate_predictions
+from .ensemble_predict_v50 import aggregate_ensemble
+from .selftest_infer import run_selftest
+from .utils_infer import (
+    InferenceConfig,
+    append_to_debug_log,
+    build_dataloader_from_config,
+    build_model_from_config,
+    compute_config_hash,
+    ensure_run_dir,
+    get_ids_from_batch,
+    load_config,
+    set_global_seed,
+    setup_logging_stack,
+    to_device,
+    validate_submission_csv,
+    write_json,
+    write_jsonl_event,
+    write_submission_csv,
+)
+from .package_submission_v50 import build_manifest, make_zip_bundle
+
+
+def _inference_single_model(
+    cfg: InferenceConfig,
+    model: torch.nn.Module,
+    device: torch.device,
+    split: str = "test",
+) -> Tuple[List[str], torch.Tensor, torch.Tensor]:
+    loader = build_dataloader_from_config(cfg, split=split)
+    ids_all: List[str] = []
+    mu_all: List[torch.Tensor] = []
+    sigma_all: List[torch.Tensor] = []
+
+    model.eval()
+    with torch.no_grad():
+        for batch in loader:
+            batch = to_device(batch, device=device)
+            mu, sigma = model(batch)
+            sigma = torch.clamp(sigma, min=1e-6)
+            ids = get_ids_from_batch(batch)
+            ids_all.extend(ids)
+            mu_all.append(mu.detach().cpu())
+            sigma_all.append(sigma.detach().cpu())
+
+    mu_full = torch.cat(mu_all, dim=0)
+    sigma_full = torch.cat(sigma_all, dim=0)
+    return ids_all, mu_full, sigma_full
+
+def predict(
+    cfg_path: Optional[str],
+    overrides: Optional[Dict[str, Any]] = None,
+    output_root: Optional[str] = None,
+    tag: Optional[str] = None,
+    selftest: bool = False,
+    deep_selftest: bool = False,
+    do_package: bool = True,
+) -> Dict[str, Any]:
+    cfg = load_config(cfg_path, overrides)
+    cfg_hash = compute_config_hash(cfg)
+    run_dir = ensure_run_dir(base=output_root, tag=tag or "predict_v50")
+    logs = setup_logging_stack(run_dir)
+    logger = logging.getLogger("spectramind.infer")
+
+    append_to_debug_log(pathlib.Path(logs["audit"]), f"- predict_v50 start | cfg_hash={cfg_hash} | tag={tag or ''}")
+
+    if selftest:
+        _ = run_selftest(cfg, run_dir=run_dir, deep=deep_selftest)
+
+    set_global_seed(cfg.seed)
+    device = torch.device(
+        cfg.device if (torch.cuda.is_available() or "cpu" not in cfg.device) else "cpu"
+    )
+    logger.info("Using device: %s", device)
+
+    model_entries: List[Dict[str, Any]] = []
+    ckpt = cfg.model.get("ckpt")
+    if isinstance(ckpt, list):
+        for i, c in enumerate(ckpt):
+            sub_cfg = InferenceConfig(**{**cfg.__dict__})
+            sub_cfg.model = {**cfg.model, "ckpt": c}
+            model_entries.append({"idx": i, "cfg": sub_cfg})
+    else:
+        model_entries.append({"idx": 0, "cfg": cfg})
+
+    ensemble_preds: List[Tuple[List[str], torch.Tensor, torch.Tensor]] = []
+    for entry in model_entries:
+        mcfg: InferenceConfig = entry["cfg"]
+        model = build_model_from_config(mcfg, device=device)
+        ids, mu, sigma = _inference_single_model(mcfg, model, device=device, split="test")
+        write_jsonl_event(pathlib.Path(logs["events"]), {"event": "model_infer_done", "model_idx": entry["idx"], "N": len(ids)})
+        ensemble_preds.append((ids, mu, sigma))
+
+    ids = ensemble_preds[0][0]
+    for i, (ids_i, _, _) in enumerate(ensemble_preds):
+        if ids_i != ids:
+            raise RuntimeError(f"ID mismatch across ensemble member {i}")
+
+    if len(ensemble_preds) == 1:
+        mu, sigma = ensemble_preds[0][1], ensemble_preds[0][2]
+        agg_summary = {"K": 1, "method_mu": "na", "method_sigma": "na"}
+    else:
+        K = len(ensemble_preds)
+        mus = [p[1] for p in ensemble_preds]
+        sigmas = [p[2] for p in ensemble_preds]
+        mu, sigma, agg_summary = aggregate_ensemble(
+            preds=list(zip(mus, sigmas)),
+            method_mu=cfg.model.get("ensemble", {}).get("mu", "mean"),
+            method_sigma=cfg.model.get("ensemble", {}).get("sigma", "geom_mean"),
+            weights=None,
+        )
+        write_json(pathlib.Path(run_dir) / "artifacts" / "ensemble_summary.json", agg_summary)
+
+    calib_target_path = cfg.calibration.get("target_path")
+    calib = None
+    if calib_target_path and os.path.exists(calib_target_path):
+        target_np = np.load(calib_target_path)
+        if target_np.shape == mu.shape:
+            calib = {"target": torch.from_numpy(target_np).to(mu.dtype)}
+        else:
+            logging.getLogger("spectramind.infer").warning(
+                "Calibration target shape mismatch; skipping calibration."
+            )
+    mu_cal, sigma_cal, cal_summary = calibrate_predictions(
+        cfg, mu=mu, sigma=sigma, calib=calib, out_dir=pathlib.Path(run_dir) / "artifacts"
+    )
+
+    out_csv = pathlib.Path(run_dir) / "submission" / "submission.csv"
+    fmt = cfg.submission.get("format", "wide")
+    write_submission_csv(out_csv, ids=ids, mu=mu_cal, sigma=sigma_cal, fmt=fmt)
+    val_summary = validate_submission_csv(out_csv, fmt=fmt, bins=cfg.bins, expect_ids=ids)
+    write_json(pathlib.Path(run_dir) / "artifacts" / "submission_validation.json", val_summary)
+    logging.getLogger("spectramind.infer").info("Submission written: %s", out_csv)
+
+    manifest = build_manifest(
+        run_dir,
+        cfg_hash=cfg_hash,
+        extras={"ensemble": agg_summary, "calibration": cal_summary},
+    )
+    zip_path = make_zip_bundle(run_dir) if do_package else None
+
+    summary = {
+        "cfg_hash": cfg_hash,
+        "ids": len(ids),
+        "bins": cfg.bins,
+        "submission": str(out_csv),
+        "bundle": str(zip_path) if zip_path else None,
+        "run_dir": str(run_dir),
+        "device": str(device),
+        "ensemble": agg_summary,
+        "calibration": cal_summary,
+        "validation": val_summary,
+    }
+    write_json(pathlib.Path(run_dir) / "artifacts" / "predict_summary.json", summary)
+    append_to_debug_log(
+        pathlib.Path(logs["audit"]),
+        f"- predict_v50 summary: {json.dumps(summary)}",
+    )
+    write_jsonl_event(pathlib.Path(logs["events"]), {"event": "predict_complete", **summary})
+
+    return summary
+
+def _parse_kv_overrides(kvs: List[str]) -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for kv in kvs:
+        if "=" not in kv:
+            continue
+        k, v = kv.split("=", 1)
+        if v.lower() in ("true", "false"):
+            vv: Any = v.lower() == "true"
+        else:
+            try:
+                vv = int(v)
+            except ValueError:
+                try:
+                    vv = float(v)
+                except ValueError:
+                    vv = v
+        out[k] = vv
+    return out
+
+
+def main() -> None:
+    p = argparse.ArgumentParser("spectramind-v50-predict")
+    p.add_argument("--config", type=str, required=False, help="Path to YAML/Hydra config (config_v50.yaml).")
+    p.add_argument("--output", type=str, required=False, default=None, help="Base output directory for run.")
+    p.add_argument("--tag", type=str, required=False, default=None, help="Optional run tag suffix.")
+    p.add_argument("--override", type=str, nargs="*", default=[], help="Override config values key=value (dotted keys allowed).")
+    p.add_argument("--selftest", action="store_true", help="Run selftest before inference.")
+    p.add_argument("--deep-selftest", action="store_true", help="Run deep selftest.")
+    p.add_argument("--no-package", action="store_true", help="Do not create zip bundle.")
+    args = p.parse_args()
+
+    overrides = _parse_kv_overrides(args.override)
+    summary = predict(
+        cfg_path=args.config,
+        overrides=overrides,
+        output_root=args.output,
+        tag=args.tag,
+        selftest=args.selftest,
+        deep_selftest=args.deep_selftest,
+        do_package=not args.no_package,
+    )
+    print(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spectramind/infer/selftest_infer.py
+++ b/src/spectramind/infer/selftest_infer.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+"""SpectraMind V50 — Inference Self-Test"""
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from typing import Any, Dict
+
+import torch
+
+from .utils_infer import (
+    InferenceConfig,
+    append_to_debug_log,
+    build_dataloader_from_config,
+    build_model_from_config,
+    ensure_run_dir,
+    get_ids_from_batch,
+    set_global_seed,
+    setup_logging_stack,
+    to_device,
+    validate_submission_csv,
+    write_json,
+    write_jsonl_event,
+    write_submission_csv,
+)
+
+
+def run_selftest(cfg: InferenceConfig, run_dir: pathlib.Path, deep: bool = False) -> Dict[str, Any]:
+    """Execute a series of small operations to confirm end-to-end viability."""
+    logger = logging.getLogger("spectramind.infer")
+    logs = setup_logging_stack(run_dir)
+    append_to_debug_log(pathlib.Path(logs["audit"]), f"- selftest started (deep={deep})")
+
+    set_global_seed(cfg.seed)
+    device = torch.device(
+        cfg.device if torch.cuda.is_available() or "cpu" not in cfg.device else "cpu"
+    )
+
+    loader = build_dataloader_from_config(cfg, split="test")
+    it = iter(loader)
+    batch = next(it)
+    logger.info("Loaded 1 batch from dataset builder.")
+
+    model = build_model_from_config(cfg, device)
+    model.eval()
+    with torch.no_grad():
+        out = model(to_device(batch, device))
+    assert isinstance(out, (tuple, list)) and len(out) == 2, "Model must return (mu, sigma)"
+    mu, sigma = out
+    assert mu.ndim == 2 and sigma.ndim == 2, "mu/sigma must be [B, bins]"
+    assert mu.shape == sigma.shape, "mu and sigma shapes mismatch"
+    assert mu.shape[1] == cfg.bins, f"Expected bins={cfg.bins}, got {mu.shape[1]}"
+    logger.info("Model forward shape checks passed: %s", list(mu.shape))
+
+    ids = get_ids_from_batch(batch)
+    art_dir = pathlib.Path(run_dir) / "artifacts"
+    sub_csv = art_dir / "sanity_submission.csv"
+    fmt = cfg.submission.get("format", "wide")
+    write_submission_csv(sub_csv, ids=ids, mu=mu, sigma=sigma, fmt=fmt)
+    v = validate_submission_csv(sub_csv, fmt=fmt, bins=cfg.bins, expect_ids=ids)
+    logger.info("Submission validator summary: %s", v)
+
+    summary = {
+        "batch_size": mu.shape[0],
+        "bins": mu.shape[1],
+        "submission": v,
+        "device": str(device),
+        "deep": deep,
+    }
+    write_json(pathlib.Path(run_dir) / "logs" / "selftest_summary.json", summary)
+    append_to_debug_log(pathlib.Path(logs["audit"]), f"- selftest summary: {json.dumps(summary)}")
+    write_jsonl_event(pathlib.Path(logs["events"]), {"event": "selftest_complete", **summary})
+    return summary

--- a/src/spectramind/infer/utils_infer.py
+++ b/src/spectramind/infer/utils_infer.py
@@ -1,0 +1,513 @@
+# -*- coding: utf-8 -*-
+"""SpectraMind V50 — Inference Utilities"""
+from __future__ import annotations
+
+import abc
+import csv
+import datetime
+import hashlib
+import importlib
+import inspect
+import json
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import torch
+import yaml
+
+try:  # optional dependency
+    from omegaconf import DictConfig, OmegaConf  # type: ignore
+except Exception:  # pragma: no cover
+    OmegaConf = None
+    DictConfig = None
+
+
+# ---------------------------
+# Typed config surface
+# ---------------------------
+
+
+@dataclass
+class InferenceConfig:
+    """Minimal inference config schema used across infer submodules."""
+
+    seed: int = 42
+    device: str = "cuda"
+    batch_size: int = 8
+    num_workers: int = 2
+    pin_memory: bool = True
+    bins: int = 283
+    data: Dict[str, Any] = field(default_factory=dict)
+    model: Dict[str, Any] = field(default_factory=dict)
+    calibration: Dict[str, Any] = field(default_factory=dict)
+    submission: Dict[str, Any] = field(default_factory=lambda: {"format": "wide"})
+    diagnostics: Dict[str, Any] = field(default_factory=dict)
+    paths: Dict[str, Any] = field(default_factory=dict)
+    run: Dict[str, Any] = field(default_factory=dict)
+    raw: Any = None
+
+
+# ---------------------------
+# Filesystem helpers
+# ---------------------------
+
+def ensure_dir(path: pathlib.Path, exist_ok: bool = True) -> pathlib.Path:
+    """Create directory if not exists; return path."""
+    path.mkdir(parents=True, exist_ok=exist_ok)
+    return path
+
+
+def ensure_run_dir(base: Optional[str] = None, tag: Optional[str] = None) -> pathlib.Path:
+    """Create a timestamped run directory for logs, artifacts, and submission."""
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    safe_tag = (tag or "infer").replace("/", "_").replace(" ", "_")
+    base_dir = pathlib.Path(base or "runs") / f"{ts}_{safe_tag}"
+    ensure_dir(base_dir)
+    ensure_dir(base_dir / "logs")
+    ensure_dir(base_dir / "artifacts")
+    ensure_dir(base_dir / "submission")
+    return base_dir
+
+
+def path_write_text(path: pathlib.Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: pathlib.Path, obj: Any, indent: int = 2) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(obj, f, indent=indent, sort_keys=True)
+
+
+def read_json(path: pathlib.Path) -> Any:
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_jsonl_event(jsonl_path: pathlib.Path, event: Dict[str, Any]) -> None:
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = dict(event)
+    payload.setdefault("timestamp", datetime.datetime.now().isoformat())
+    with jsonl_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(payload) + "\n")
+
+
+def append_to_debug_log(md_path: pathlib.Path, text: str) -> None:
+    md_path.parent.mkdir(parents=True, exist_ok=True)
+    with md_path.open("a", encoding="utf-8") as f:
+        f.write(text.rstrip() + "\n")
+
+# ---------------------------
+# Logging stack
+# ---------------------------
+
+def setup_logging_stack(
+    run_dir: pathlib.Path,
+    level: int = logging.INFO,
+    name: str = "spectramind.infer",
+) -> Dict[str, pathlib.Path]:
+    """Configure a rotating file logger, a JSONL event stream, and an audit log."""
+    log_dir = ensure_dir(run_dir / "logs")
+    log_path = log_dir / "v50_infer.log"
+    jsonl_path = log_dir / "events_infer.jsonl"
+    audit_md = log_dir / "v50_debug_log.md"
+
+    logger = logging.getLogger(name)
+    logger.handlers.clear()
+    logger.setLevel(level)
+
+    ch = logging.StreamHandler(stream=sys.stdout)
+    ch.setLevel(level)
+    ch.setFormatter(logging.Formatter("[%(levelname)s] %(message)s"))
+    logger.addHandler(ch)
+
+    from logging.handlers import RotatingFileHandler
+
+    fh = RotatingFileHandler(
+        log_path, mode="a", maxBytes=5 * 1024 * 1024, backupCount=3, encoding="utf-8"
+    )
+    fh.setLevel(level)
+    fh.setFormatter(
+        logging.Formatter("%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+    )
+    logger.addHandler(fh)
+
+    write_jsonl_event(jsonl_path, {"event": "logging_initialized", "level": level})
+    append_to_debug_log(
+        audit_md,
+        f"### Boot: {datetime.datetime.now().isoformat()} — logging initialized",
+    )
+
+    return {"log": log_path, "events": jsonl_path, "audit": audit_md}
+
+
+# ---------------------------
+# Config loading & hashing
+# ---------------------------
+
+def _dict_hash(d: Any) -> str:
+    try:
+        blob = json.dumps(d, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    except TypeError:
+        blob = str(d).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:16]
+
+
+def compute_config_hash(cfg: InferenceConfig) -> str:
+    structure = {
+        "seed": cfg.seed,
+        "device": cfg.device,
+        "batch_size": cfg.batch_size,
+        "num_workers": cfg.num_workers,
+        "bins": cfg.bins,
+        "model": cfg.model,
+        "data": cfg.data,
+        "calibration": cfg.calibration,
+        "submission": cfg.submission,
+        "diagnostics": cfg.diagnostics,
+    }
+    return _dict_hash(structure)
+
+
+def load_config(
+    cfg_path: Optional[str] = None, overrides: Optional[Mapping[str, Any]] = None
+) -> InferenceConfig:
+    raw: Any = None
+    if cfg_path and os.path.exists(cfg_path):
+        if OmegaConf is not None:
+            raw = OmegaConf.load(cfg_path)
+            raw = OmegaConf.to_container(raw, resolve=True)
+        else:
+            with open(cfg_path, "r", encoding="utf-8") as f:
+                raw = yaml.safe_load(f)
+    else:
+        raw = {}
+
+    if overrides:
+        for k, v in overrides.items():
+            _assign_dotted(raw, k, v)
+
+    icfg = InferenceConfig(
+        seed=raw.get("seed", 42),
+        device=raw.get("device", "cuda"),
+        batch_size=int(raw.get("batch_size", 8)),
+        num_workers=int(raw.get("num_workers", 2)),
+        pin_memory=bool(raw.get("pin_memory", True)),
+        bins=int(_get_nested(raw, "bins", 283)),
+        data=dict(raw.get("data", {})),
+        model=dict(raw.get("model", {})),
+        calibration=dict(raw.get("calibration", {})),
+        submission=dict(raw.get("submission", {"format": "wide"})),
+        diagnostics=dict(raw.get("diagnostics", {})),
+        paths=dict(raw.get("paths", {})),
+        run=dict(raw.get("run", {})),
+        raw=raw,
+    )
+    return icfg
+
+
+def _assign_dotted(dct: Dict[str, Any], dotted: str, value: Any) -> None:
+    parts = dotted.split(".")
+    cur = dct
+    for p in parts[:-1]:
+        if p not in cur or not isinstance(cur[p], dict):
+            cur[p] = {}
+        cur = cur[p]
+    cur[parts[-1]] = value
+
+
+def _get_nested(dct: Mapping[str, Any], dotted: str, default: Any = None) -> Any:
+    cur: Any = dct
+    for p in dotted.split("."):
+        if not isinstance(cur, Mapping) or p not in cur:
+            return default
+        cur = cur[p]
+    return cur
+
+# ---------------------------
+# Git and environment capture
+# ---------------------------
+
+def capture_git_state(repo_root: Optional[str] = None) -> Dict[str, Any]:
+    """Best-effort git state capture."""
+    repo_root = repo_root or "."
+
+    def _run(cmd: List[str]) -> str:
+        try:
+            out = subprocess.check_output(cmd, cwd=repo_root, stderr=subprocess.DEVNULL)
+            return out.decode("utf-8").strip()
+        except Exception:
+            return ""
+
+    return {
+        "commit": _run(["git", "rev-parse", "HEAD"]),
+        "branch": _run(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+        "dirty": bool(_run(["git", "status", "--porcelain"])),
+        "remote": _run(["git", "remote", "-v"]),
+    }
+
+
+def capture_python_env() -> Dict[str, Any]:
+    """Capture minimal Python environment info."""
+    return {
+        "python": sys.version,
+        "executable": sys.executable,
+        "platform": sys.platform,
+        "torch": getattr(torch, "__version__", "unknown"),
+        "cuda": torch.version.cuda if torch.cuda.is_available() else None,
+        "cuda_available": torch.cuda.is_available(),
+        "cudnn": torch.backends.cudnn.version() if torch.cuda.is_available() else None,
+    }
+
+
+# ---------------------------
+# Model & dataset dynamic loading
+# ---------------------------
+
+
+class InferenceModel(abc.ABC, torch.nn.Module):
+    """Minimal protocol for a model used in this pipeline."""
+
+    @abc.abstractmethod
+    def forward(self, batch: Mapping[str, Any]) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return (mu, sigma)."""
+
+
+def import_from_path(qualified: str) -> Any:
+    """Import a symbol from a fully qualified path 'package.module:Class'."""
+    if ":" in qualified:
+        mod_name, sym_name = qualified.split(":", 1)
+    else:
+        parts = qualified.split(".")
+        mod_name, sym_name = ".".join(parts[:-1]), parts[-1]
+    module = importlib.import_module(mod_name)
+    return getattr(module, sym_name)
+
+
+def build_model_from_config(cfg: InferenceConfig, device: torch.device) -> InferenceModel:
+    model_def = cfg.model.get("registry") or cfg.model.get("class")
+    model_kwargs = cfg.model.get("kwargs", {})
+    ckpt = cfg.model.get("ckpt")
+    if model_def:
+        symbol = import_from_path(model_def)
+        model = (
+            symbol(**model_kwargs)
+            if inspect.isclass(symbol)
+            else symbol(cfg=cfg, **model_kwargs)
+        )
+        if not isinstance(model, torch.nn.Module):
+            raise ValueError(
+                f"Model registry/class did not return nn.Module: {type(model)}"
+            )
+        model = model.to(device)
+        if ckpt and isinstance(ckpt, str) and ckpt.endswith(".pth"):
+            _load_state_dict_safe(model, ckpt, device)
+        return model  # type: ignore[return-value]
+    if ckpt and isinstance(ckpt, str) and ckpt.endswith(".pt"):
+        ts_model = torch.jit.load(ckpt, map_location=device)
+        if not isinstance(ts_model, torch.nn.Module):
+            raise ValueError("TorchScript object is not an nn.Module")
+        return ts_model  # type: ignore[return-value]
+    raise ValueError(
+        "No valid model route found. Provide model.registry/class or TorchScript ckpt."
+    )
+
+
+def _load_state_dict_safe(
+    model: torch.nn.Module, ckpt_path: str, device: torch.device
+) -> None:
+    state = torch.load(ckpt_path, map_location=device)
+    if "state_dict" in state:
+        state = state["state_dict"]
+    missing, unexpected = model.load_state_dict(state, strict=False)
+    logger = logging.getLogger("spectramind.infer")
+    if missing:
+        logger.warning("Missing keys in state_dict: %s", missing)
+    if unexpected:
+        logger.warning("Unexpected keys in state_dict: %s", unexpected)
+
+
+def build_dataloader_from_config(
+    cfg: InferenceConfig, split: str
+) -> Iterable[Dict[str, Any]]:
+    logger = logging.getLogger("spectramind.infer")
+    bs = cfg.batch_size
+    nw = cfg.num_workers
+    pm = cfg.pin_memory
+
+    split_over = (cfg.data.get("split_overrides") or {}).get(split, {})
+    kwargs = dict(cfg.data.get("kwargs", {}))
+    kwargs.update(split_over)
+
+    if "registry" not in cfg.data:
+        raise ValueError("cfg.data.registry not set (expected 'module:builder' path).")
+    builder = import_from_path(cfg.data["registry"])
+    dataset = builder(split=split, cfg=cfg, **kwargs)
+
+    collate_fn = None
+    if cfg.data.get("collate"):
+        collate_fn = import_from_path(cfg.data["collate"])
+
+    if cfg.data.get("loader"):
+        loader_builder = import_from_path(cfg.data["loader"])
+        return loader_builder(
+            dataset=dataset,
+            batch_size=bs,
+            num_workers=nw,
+            pin_memory=pm,
+            collate_fn=collate_fn,
+        )
+
+    from torch.utils.data import DataLoader
+
+    return DataLoader(
+        dataset,
+        batch_size=bs,
+        num_workers=nw,
+        pin_memory=pm,
+        shuffle=False,
+        drop_last=False,
+        collate_fn=collate_fn,
+    )
+
+# ---------------------------
+# Submission writer & validator
+# ---------------------------
+
+def write_submission_csv(
+    out_csv: pathlib.Path,
+    ids: Sequence[str],
+    mu: torch.Tensor,
+    sigma: torch.Tensor,
+    fmt: str = "wide",
+) -> None:
+    out_csv.parent.mkdir(parents=True, exist_ok=True)
+    mu = mu.detach().cpu()
+    sigma = sigma.detach().cpu()
+    N, B = mu.shape
+    if fmt not in {"wide", "long"}:
+        raise ValueError("submission.format must be 'wide' or 'long'")
+
+    if fmt == "wide":
+        fieldnames = ["id"] + [f"mu_{i:03d}" for i in range(B)] + [
+            f"sigma_{i:03d}" for i in range(B)
+        ]
+        with out_csv.open("w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=fieldnames)
+            w.writeheader()
+            for row_idx in range(N):
+                row = {"id": ids[row_idx]}
+                for i in range(B):
+                    row[f"mu_{i:03d}"] = float(mu[row_idx, i].item())
+                for i in range(B):
+                    val = float(max(0.0, sigma[row_idx, i].item()))
+                    row[f"sigma_{i:03d}"] = val
+                w.writerow(row)
+    else:
+        with out_csv.open("w", newline="", encoding="utf-8") as f:
+            w = csv.DictWriter(f, fieldnames=["id", "bin", "mu", "sigma"])
+            w.writeheader()
+            for row_idx in range(N):
+                for i in range(B):
+                    w.writerow(
+                        {
+                            "id": ids[row_idx],
+                            "bin": i,
+                            "mu": float(mu[row_idx, i].item()),
+                            "sigma": float(max(0.0, sigma[row_idx, i].item())),
+                        }
+                    )
+
+
+def validate_submission_csv(
+    csv_path: pathlib.Path,
+    fmt: str,
+    bins: int,
+    expect_ids: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    with csv_path.open("r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    if fmt == "wide":
+        required = {"id"} | {f"mu_{i:03d}" for i in range(bins)} | {
+            f"sigma_{i:03d}" for i in range(bins)
+        }
+        missing = required - set(reader.fieldnames or [])
+        if missing:
+            raise ValueError(
+                f"Submission missing columns: {sorted(missing)[:8]} ..."
+            )
+        ids = [r["id"] for r in rows]
+        unique_ids = len(set(ids))
+        if expect_ids is not None and set(ids) != set(expect_ids):
+            raise ValueError("Submission IDs do not match expected test IDs.")
+        return {
+            "rows": len(rows),
+            "unique_ids": unique_ids,
+            "format": "wide",
+            "bins": bins,
+        }
+    elif fmt == "long":
+        if expect_ids is not None and len(rows) != len(expect_ids) * bins:
+            raise ValueError("Long submission has incorrect row count.")
+        for r in rows[:10]:
+            for k in ["id", "bin", "mu", "sigma"]:
+                if k not in r:
+                    raise ValueError(f"Missing column {k} in long submission.")
+        return {"rows": len(rows), "format": "long", "bins": bins}
+    else:
+        raise ValueError("Unknown format for validation.")
+
+
+# ---------------------------
+# Misc small helpers
+# ---------------------------
+
+def set_global_seed(seed: int) -> None:
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+def to_device(batch: Mapping[str, Any], device: torch.device) -> Dict[str, Any]:
+    out = {}
+    for k, v in batch.items():
+        if isinstance(v, torch.Tensor):
+            out[k] = v.to(device, non_blocking=True)
+        elif isinstance(v, (list, tuple)):
+            out[k] = [
+                x.to(device, non_blocking=True) if isinstance(x, torch.Tensor) else x
+                for x in v
+            ]
+        elif isinstance(v, dict):
+            out[k] = to_device(v, device)
+        else:
+            out[k] = v
+    return out
+
+
+def get_ids_from_batch(batch: Mapping[str, Any]) -> List[str]:
+    for key in ("id", "ids", "planet_id", "planet_ids"):
+        if key in batch:
+            val = batch[key]
+            if isinstance(val, (list, tuple)):
+                return [str(x) for x in val]
+            if isinstance(val, torch.Tensor) and val.ndim == 1:
+                return [str(x.item()) for x in val]
+            return [str(val)]
+    bs = None
+    for v in batch.values():
+        if isinstance(v, torch.Tensor):
+            bs = v.shape[0]
+            break
+        if isinstance(v, (list, tuple)):
+            bs = len(v)
+            break
+    return [f"sample_{i:06d}" for i in range(bs or 0)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path so `import src` works during tests
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- implement comprehensive SpectraMind V50 inference stack with config handling, logging, calibration, packaging and prediction
- fix fusion factory to read `fusion` configs at top level, add trace-friendly identity fusion and freeze parameters for JIT
- ensure tests import src package reliably

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f421d7a00832aa3f76de1ecbd58b7