### PR TITLE
Add symbolic weights subsystem with logging and CLI

### DIFF
--- a/src/spectramind/symbolic/weights/README.md
+++ b/src/spectramind/symbolic/weights/README.md
@@ -1,0 +1,31 @@
+# SpectraMind V50 — Symbolic Weights Subsystem
+
+This package provides:
+
+- Declarative YAML weight sets for symbolic constraints
+- Deterministic composition and validation
+- Metric-driven optimization with bounded, conservative updates
+- Mission-grade logging (console + rotating file) and JSONL event stream
+- Typer CLI (`python -m spectramind.symbolic.weights.cli`)
+
+## Quickstart
+
+Compose defaults:
+
+```bash
+python -m spectramind.symbolic.weights.cli compose
+```
+
+Compose with composite profile:
+
+```bash
+python -m spectramind.symbolic.weights.cli compose --profile-name hot_jupiter --json-out weights_hot_jupiter.json
+```
+
+Optimize from metrics:
+
+```bash
+python -m spectramind.symbolic.weights.cli optimize weights_hot_jupiter.json metrics.json --out-json weights_hot_jupiter_optimized.json
+```
+
+Logs: `logs/symbolic_weights.log`, events: `logs/symbolic_weights.events.jsonl`.

--- a/src/spectramind/symbolic/weights/__init__.py
+++ b/src/spectramind/symbolic/weights/__init__.py
@@ -1,0 +1,40 @@
+"""SpectraMind V50 — Symbolic Weights Subsystem.
+
+Exports: loading, validation, optimization, profiles, CLI app hook.
+This package is Hydra-safe (pure-Python YAML loading), logs to console and rotating file,
+and emits a JSONL event stream for reproducibility.
+"""
+
+from .auto_weight_optimizer import (
+    OptimizationConfig,
+    apply_metric_driven_adjustments,
+    optimize_symbolic_weights,
+)
+from .cli import app as cli_app
+from .loader import (
+    compose_weights,
+    list_available_weight_sets,
+    load_all_known_weights,
+    load_symbolic_weights,
+)
+from .validator import (
+    WeightProfileSchema,
+    WeightSchema,
+    validate_profile_weights,
+    validate_weight_config,
+)
+
+__all__ = [
+    "load_symbolic_weights",
+    "list_available_weight_sets",
+    "compose_weights",
+    "load_all_known_weights",
+    "WeightSchema",
+    "WeightProfileSchema",
+    "validate_weight_config",
+    "validate_profile_weights",
+    "optimize_symbolic_weights",
+    "OptimizationConfig",
+    "apply_metric_driven_adjustments",
+    "cli_app",
+]

--- a/src/spectramind/symbolic/weights/_selftest.py
+++ b/src/spectramind/symbolic/weights/_selftest.py
@@ -1,0 +1,16 @@
+"""Lightweight smoke test for local validation. Safe to run in CI."""
+
+from __future__ import annotations
+
+from .loader import compose_weights
+from .validator import validate_weight_config
+
+
+def run() -> None:
+    w = compose_weights(profile_name="hot_jupiter")
+    validate_weight_config(w)
+    print("OK", len(w))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    run()

--- a/src/spectramind/symbolic/weights/auto_weight_optimizer.py
+++ b/src/spectramind/symbolic/weights/auto_weight_optimizer.py
@@ -1,0 +1,87 @@
+"""Metric-driven symbolic weight optimization."""
+
+from __future__ import annotations
+
+import copy
+import math
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+from .logging_utils import emit_event, get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass
+class OptimizationConfig:
+    """Tunable knobs for optimization."""
+
+    target: float = 1.0
+    step: float = 0.10
+    min_delta: float = -0.25
+    max_delta: float = 0.25
+    absolute_clip_min: float = 0.0
+    absolute_clip_max: float = 10.0
+    dry_run: bool = False
+
+
+def _bounded_adjust(cur_w: float, error: float, cfg: OptimizationConfig) -> float:
+    """Compute a bounded relative adjustment based on error = (target - metric).
+
+    Positive error -> increase weight; negative -> decrease.
+    """
+    # Proportional term with a smooth squashing for large errors.
+    raw_rel = cfg.step * math.tanh(error)
+    rel = max(cfg.min_delta, min(cfg.max_delta, raw_rel))
+    new_val = cur_w * (1.0 + rel)
+    return max(cfg.absolute_clip_min, min(cfg.absolute_clip_max, new_val))
+
+
+def apply_metric_driven_adjustments(
+    weights: Dict[str, float],
+    metrics: Dict[str, float],
+    cfg: OptimizationConfig,
+) -> Dict[str, float]:
+    updated = copy.deepcopy(weights)
+    changes: Dict[str, Tuple[float, float]] = {}
+    for rule, cur_w in weights.items():
+        if not isinstance(cur_w, (int, float)):
+            continue
+        if rule not in metrics:
+            continue
+        m = metrics[rule]
+        error = cfg.target - m
+        new_w = _bounded_adjust(float(cur_w), error, cfg)
+        if cfg.dry_run:
+            # Do not mutate; just record preview
+            changes[rule] = (float(cur_w), new_w)
+        else:
+            updated[rule] = new_w
+            changes[rule] = (float(cur_w), new_w)
+
+    LOGGER.info("weight_adjustments", extra={"num_rules": len(changes)})
+    emit_event(
+        "weights_adjusted",
+        {
+            "changes": {k: {"old": a, "new": b} for k, (a, b) in changes.items()},
+            "dry_run": cfg.dry_run,
+        },
+    )
+    return updated
+
+
+def optimize_symbolic_weights(
+    base_weights: Dict[str, float],
+    performance_metrics: Dict[str, float] | None = None,
+    cfg: OptimizationConfig | None = None,
+) -> Dict[str, float]:
+    """Optimize weights given performance metrics; if metrics is None, returns base unchanged."""
+    if not performance_metrics:
+        LOGGER.warning(
+            "optimize_no_metrics",
+            extra={"message": "No metrics provided; returning base weights"},
+        )
+        emit_event("optimize_skipped", {"reason": "no_metrics"})
+        return dict(base_weights)
+    ocfg = cfg or OptimizationConfig()
+    return apply_metric_driven_adjustments(base_weights, performance_metrics, ocfg)

--- a/src/spectramind/symbolic/weights/base_weights.yaml
+++ b/src/spectramind/symbolic/weights/base_weights.yaml
@@ -1,0 +1,7 @@
+# Baseline symbolic loss weights (applies to all planets unless overridden)
+
+smoothness: 1.0
+nonnegativity: 1.0
+molecule_region: 1.0
+seam_continuity: 1.0
+quantile_monotonicity: 1.0

--- a/src/spectramind/symbolic/weights/cli.py
+++ b/src/spectramind/symbolic/weights/cli.py
@@ -1,0 +1,106 @@
+"""Typer CLI for the weights subsystem."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+
+from .auto_weight_optimizer import OptimizationConfig, optimize_symbolic_weights
+from .loader import compose_weights, list_available_weight_sets
+from .logging_utils import get_logger
+from .validator import validate_weight_config
+
+app = typer.Typer(no_args_is_help=True, add_completion=True)
+LOGGER = get_logger(__name__)
+
+
+@app.command("list")
+def list_weights() -> None:
+    """List available YAML weight files shipped with this package."""
+    for name in list_available_weight_sets():
+        typer.echo(name)
+
+
+@app.command("compose")
+def compose(
+    profile_name: Optional[str] = typer.Option(
+        None, "--profile-name", help="Name inside composite_profile_weights.yaml"
+    ),
+    profile_file: Optional[str] = typer.Option(
+        None, "--profile-file", help="profiles/*.yaml or absolute path"
+    ),
+    base_files: Optional[List[str]] = typer.Option(
+        None,
+        "--base",
+        help="Explicit base/penalty YAML list (defaults used if omitted)",
+    ),
+    directory: Optional[Path] = typer.Option(
+        None, "--dir", help="Directory containing YAML files (default: package dir)"
+    ),
+    json_out: Optional[Path] = typer.Option(
+        None, "--json-out", help="Save composed weights to JSON file"
+    ),
+) -> None:
+    """Compose final weights (base + penalties + molecule + profile) and print as JSON."""
+    weights = compose_weights(
+        base_files=base_files,
+        directory=directory,
+        profile_file=profile_file,
+        profile_name=profile_name,
+    )
+    validate_weight_config(weights)
+    out = json.dumps(weights, indent=2, sort_keys=True)
+    typer.echo(out)
+    if json_out:
+        json_out.parent.mkdir(parents=True, exist_ok=True)
+        json_out.write_text(out, encoding="utf-8")
+        typer.echo(f"Wrote {json_out}")
+
+
+@app.command("optimize")
+def optimize(
+    weights_json: Path = typer.Argument(
+        ..., help="Input weights JSON (from compose or hand-authored)"
+    ),
+    metrics_json: Path = typer.Argument(
+        ..., help="Performance metrics JSON {rule: metric}"
+    ),
+    target: float = typer.Option(1.0, help="Target metric value"),
+    step: float = typer.Option(0.10, help="Base proportional step"),
+    min_delta: float = typer.Option(-0.25, help="Min relative change"),
+    max_delta: float = typer.Option(0.25, help="Max relative change"),
+    clip_min: float = typer.Option(0.0, help="Absolute minimum"),
+    clip_max: float = typer.Option(10.0, help="Absolute maximum"),
+    dry_run: bool = typer.Option(False, help="Preview adjustments without applying"),
+    out_json: Optional[Path] = typer.Option(
+        None, "--out-json", help="Save optimized weights JSON here"
+    ),
+) -> None:
+    """Optimize weights given metrics; prints updated JSON (or preview if --dry-run)."""
+    weights = json.loads(weights_json.read_text(encoding="utf-8"))
+    metrics = json.loads(metrics_json.read_text(encoding="utf-8"))
+
+    cfg = OptimizationConfig(
+        target=target,
+        step=step,
+        min_delta=min_delta,
+        max_delta=max_delta,
+        absolute_clip_min=clip_min,
+        absolute_clip_max=clip_max,
+        dry_run=dry_run,
+    )
+    updated = optimize_symbolic_weights(weights, metrics, cfg)
+    validate_weight_config(updated)
+    out = json.dumps(updated, indent=2, sort_keys=True)
+    typer.echo(out)
+    if out_json:
+        out_json.parent.mkdir(parents=True, exist_ok=True)
+        out_json.write_text(out, encoding="utf-8")
+        typer.echo(f"Wrote {out_json}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/spectramind/symbolic/weights/composite_profile_weights.yaml
+++ b/src/spectramind/symbolic/weights/composite_profile_weights.yaml
@@ -1,0 +1,26 @@
+# Composite profile presets — these are merged after base/penalties/molecule-region
+
+hot_jupiter:
+  smoothness: 1.20
+  nonnegativity: 1.00
+  molecule_region: 1.30
+  seam_continuity: 0.90
+  quantile_monotonicity: 1.10
+warm_neptune:
+  smoothness: 1.10
+  nonnegativity: 1.00
+  molecule_region: 1.20
+  seam_continuity: 1.00
+  quantile_monotonicity: 1.00
+super_earth:
+  smoothness: 1.30
+  nonnegativity: 1.20
+  molecule_region: 1.00
+  seam_continuity: 1.00
+  quantile_monotonicity: 1.20
+temperate_mini_neptune:
+  smoothness: 1.25
+  nonnegativity: 1.10
+  molecule_region: 1.10
+  seam_continuity: 1.00
+  quantile_monotonicity: 1.15

--- a/src/spectramind/symbolic/weights/loader.py
+++ b/src/spectramind/symbolic/weights/loader.py
@@ -1,0 +1,164 @@
+"""Unified loader for symbolic weights (YAML), with composition logic.
+
+Features:
+    • Deterministic YAML loading (yaml.safe_load) and stable merges
+    • Weight composition: base + penalties + molecule-region + profile overrides
+    • Discovery helpers and manifest hashing for reproducibility
+    • Structured logging and JSONL event emission
+"""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+import yaml
+
+from .logging_utils import emit_event, get_logger
+
+LOGGER = get_logger(__name__)
+PKG_DIR = Path(__file__).resolve().parent
+
+# Default YAML files in this package; these can be overridden by Hydra/config paths if desired.
+DEFAULT_WEIGHT_FILES = [
+    "base_weights.yaml",
+    "smoothness_penalty.yaml",
+    "nonnegativity_penalty.yaml",
+    "seam_continuity_penalty.yaml",
+    "quantile_monotonicity.yaml",
+    "molecule_region_weights.yaml",
+]
+
+
+def _read_yaml(p: Path) -> Dict[str, Any]:
+    """Read a YAML file safely and return a dict. Raises on missing file or parse error."""
+    if not p.exists():
+        raise FileNotFoundError(f"YAML not found: {p}")
+    with p.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise TypeError(f"YAML must map to dict at top-level: {p}")
+    return data
+
+
+def _deep_merge(dst: Dict[str, Any], src: Dict[str, Any]) -> Dict[str, Any]:
+    """Deep-merge src into dst (in place) with right-precedence.
+
+    Numeric leaves overwrite; dicts recurse; lists overwrite (right wins).
+    """
+    for k, v in src.items():
+        if isinstance(v, dict) and isinstance(dst.get(k), dict):
+            _deep_merge(dst[k], v)
+        else:
+            dst[k] = v
+    return dst
+
+
+def list_available_weight_sets(directory: Path | None = None) -> List[str]:
+    """List .yaml weight files in the weights directory (no profiles)."""
+    d = directory or PKG_DIR
+    names: List[str] = []
+    for p in sorted(d.glob("*.yaml")):
+        names.append(p.name)
+    return names
+
+
+def load_symbolic_weights(
+    filename: str, directory: Path | None = None
+) -> Dict[str, Any]:
+    """Load a single weight YAML by filename from given directory (defaults to package dir)."""
+    d = directory or PKG_DIR
+    cfg = _read_yaml(d / filename)
+    LOGGER.info(
+        "loaded_weight_file",
+        extra={"file": str(d / filename), "keys": list(cfg.keys())},
+    )
+    emit_event("weights_loaded", {"file": str(d / filename), "keys": list(cfg.keys())})
+    return cfg
+
+
+def load_all_known_weights(
+    files: List[str] | None = None, directory: Path | None = None
+) -> List[Tuple[str, Dict[str, Any]]]:
+    """Load all specified YAML weight files (or defaults) and return (filename, dict) list."""
+    d = directory or PKG_DIR
+    names = files or DEFAULT_WEIGHT_FILES
+    out: List[Tuple[str, Dict[str, Any]]] = []
+    for name in names:
+        out.append((name, load_symbolic_weights(name, d)))
+    return out
+
+
+def compose_weights(
+    base_files: List[str] | None = None,
+    directory: Path | None = None,
+    profile_file: str | None = None,
+    profile_name: str | None = None,
+) -> Dict[str, Any]:
+    """Compose final weights in precedence order:
+
+    1) base/penalties/molecule-region defaults
+    2) composite_profile_weights.yaml[profile_name] (if provided)
+    3) explicit profile YAML file (if provided)
+
+    Returns a flat dict of weights usable by symbolic_loss and friends.
+    """
+    d = directory or PKG_DIR
+    merged: Dict[str, Any] = {}
+
+    # Step 1: defaults
+    for fname, cfg in load_all_known_weights(base_files, d):
+        LOGGER.debug("merge_weight_file", extra={"file": fname})
+        _deep_merge(merged, cfg)
+
+    # Step 2: composite profile
+    if profile_name:
+        comp = _read_yaml(d / "composite_profile_weights.yaml")
+        if profile_name not in comp:
+            raise KeyError(
+                f"Profile '{profile_name}' not found in composite_profile_weights.yaml"
+            )
+        LOGGER.info("apply_composite_profile", extra={"profile": profile_name})
+        _deep_merge(merged, comp[profile_name])
+
+    # Step 3: explicit profile file (e.g., profiles/hot_jupiter.yaml)
+    if profile_file:
+        p = (
+            d / "profiles" / profile_file
+            if not profile_file.startswith("/")
+            else Path(profile_file)
+        )
+        LOGGER.info("apply_profile_file", extra={"profile_file": str(p)})
+        prof_dict = _read_yaml(p)
+        _deep_merge(merged, prof_dict)
+
+    manifest = _manifest_for_config(merged)
+    LOGGER.info(
+        "compose_weights_done",
+        extra={"num_keys": len(merged), "hash": manifest.config_hash},
+    )
+    emit_event(
+        "weights_composed", {"num_keys": len(merged), "hash": manifest.config_hash}
+    )
+    return merged
+
+
+@dataclass(frozen=True)
+class Manifest:
+    files: List[str]
+    config_hash: str
+
+
+def _manifest_for_config(
+    cfg: Dict[str, Any], files: List[str] | None = None
+) -> Manifest:
+    """Compute a stable SHA256 hash for the composed config; record contributing files if provided."""
+    buf = io.BytesIO(
+        json.dumps(cfg, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    )
+    h = hashlib.sha256(buf.getvalue()).hexdigest()
+    return Manifest(files=files or list_available_weight_sets(), config_hash=h)

--- a/src/spectramind/symbolic/weights/logging_utils.py
+++ b/src/spectramind/symbolic/weights/logging_utils.py
@@ -1,0 +1,55 @@
+"""Logging helpers for the weights subsystem."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Dict
+
+DEFAULT_LOG_DIR = Path(os.environ.get("SPECTRAMIND_LOG_DIR", "logs"))
+DEFAULT_LOG_DIR.mkdir(parents=True, exist_ok=True)
+
+TEXT_LOG = DEFAULT_LOG_DIR / "symbolic_weights.log"
+EVENT_LOG = DEFAULT_LOG_DIR / "symbolic_weights.events.jsonl"
+
+_logger_cache: Dict[str, logging.Logger] = {}
+
+
+def get_logger(name: str = "spectramind.symbolic.weights") -> logging.Logger:
+    if name in _logger_cache:
+        return _logger_cache[name]
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.INFO)
+
+    # Avoid double handlers if re-imported
+    if not logger.handlers:
+        # Console
+        ch = logging.StreamHandler()
+        ch.setLevel(logging.INFO)
+        ch.setFormatter(
+            logging.Formatter("[%(asctime)s] %(levelname)s %(name)s: %(message)s")
+        )
+        logger.addHandler(ch)
+
+        # Rotating file
+        fh = RotatingFileHandler(
+            TEXT_LOG, maxBytes=2_000_000, backupCount=3, encoding="utf-8"
+        )
+        fh.setLevel(logging.INFO)
+        fh.setFormatter(
+            logging.Formatter("%(asctime)s\t%(levelname)s\t%(name)s\t%(message)s")
+        )
+        logger.addHandler(fh)
+
+    _logger_cache[name] = logger
+    return logger
+
+
+def emit_event(event_type: str, payload: Dict[str, Any]) -> None:
+    DEFAULT_LOG_DIR.mkdir(parents=True, exist_ok=True)
+    with EVENT_LOG.open("a", encoding="utf-8") as f:
+        rec = {"type": event_type, "payload": payload}
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")

--- a/src/spectramind/symbolic/weights/molecule_region_weights.yaml
+++ b/src/spectramind/symbolic/weights/molecule_region_weights.yaml
@@ -1,0 +1,11 @@
+# Per-molecule and region weights; used by molecule-region symbolic constraints
+
+H2O: 1.20
+CH4: 1.00
+CO2: 1.10
+CO: 0.90
+NH3: 1.00
+HCN: 0.80
+VO: 0.70
+TiO: 0.70
+region_seam: 0.50

--- a/src/spectramind/symbolic/weights/nonnegativity_penalty.yaml
+++ b/src/spectramind/symbolic/weights/nonnegativity_penalty.yaml
@@ -1,0 +1,4 @@
+# Nonnegativity constraints for μ (penalize sub-zero predictions)
+
+negative_bin_penalty: 3.00
+epsilon_tolerance: 1.0e-6

--- a/src/spectramind/symbolic/weights/profiles/__init__.py
+++ b/src/spectramind/symbolic/weights/profiles/__init__.py
@@ -1,0 +1,1 @@
+"""Profiles namespace for explicit per-class overrides."""

--- a/src/spectramind/symbolic/weights/profiles/hot_jupiter.yaml
+++ b/src/spectramind/symbolic/weights/profiles/hot_jupiter.yaml
@@ -1,0 +1,8 @@
+# Hot Jupiter explicit overrides (applied last if selected via --profile-file)
+
+H2O: 1.35
+CO: 1.05
+CO2: 1.15
+CH4: 0.85
+fft_high_freq_penalty: 1.60
+seam_penalty: 0.95

--- a/src/spectramind/symbolic/weights/profiles/super_earth.yaml
+++ b/src/spectramind/symbolic/weights/profiles/super_earth.yaml
@@ -1,0 +1,6 @@
+# Super-Earth explicit overrides
+
+smoothness: 1.40
+nonnegativity: 1.25
+HCN: 0.90
+TiO: 0.65

--- a/src/spectramind/symbolic/weights/profiles/temperate_mini_neptune.yaml
+++ b/src/spectramind/symbolic/weights/profiles/temperate_mini_neptune.yaml
@@ -1,0 +1,6 @@
+# Temperate Mini-Neptune explicit overrides
+
+smoothness: 1.30
+H2O: 1.20
+CO2: 1.12
+neighbor_weight: 0.85

--- a/src/spectramind/symbolic/weights/profiles/warm_neptune.yaml
+++ b/src/spectramind/symbolic/weights/profiles/warm_neptune.yaml
@@ -1,0 +1,7 @@
+# Warm Neptune explicit overrides
+
+H2O: 1.25
+NH3: 1.10
+CH4: 1.05
+q05_q50_violation: 1.45
+q50_q95_violation: 1.45

--- a/src/spectramind/symbolic/weights/quantile_monotonicity.yaml
+++ b/src/spectramind/symbolic/weights/quantile_monotonicity.yaml
@@ -1,0 +1,4 @@
+# Quantile monotonicity constraints for distributional decoders
+
+q05_q50_violation: 1.50
+q50_q95_violation: 1.50

--- a/src/spectramind/symbolic/weights/seam_continuity_penalty.yaml
+++ b/src/spectramind/symbolic/weights/seam_continuity_penalty.yaml
@@ -1,0 +1,4 @@
+# Continuity across AIRS/FGS1 seams and detector join regions
+
+seam_penalty: 1.20
+neighbor_weight: 0.80

--- a/src/spectramind/symbolic/weights/smoothness_penalty.yaml
+++ b/src/spectramind/symbolic/weights/smoothness_penalty.yaml
@@ -1,0 +1,5 @@
+# Smoothness constraints (μ) — binwise and spectral-domain
+
+binwise_scale: 1.00
+fft_high_freq_penalty: 1.50
+outlier_bin_penalty: 2.00

--- a/src/spectramind/symbolic/weights/validator.py
+++ b/src/spectramind/symbolic/weights/validator.py
@@ -1,0 +1,86 @@
+"""Schema validation for weights and profiles.
+
+We keep dependencies minimal (no pydantic) to remain challenge-safe.
+Rules:
+    • All top-level values numeric >= 0 OR nested dicts with numeric leaves >= 0
+    • Known keys are not strictly enforced to allow forward-compat config, but we log unknown types
+    • Profiles may be nested; validation recurses
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Tuple
+
+from .logging_utils import emit_event, get_logger
+
+LOGGER = get_logger(__name__)
+
+
+@dataclass
+class WeightSchema:
+    allow_nested: bool = True
+    require_non_negative: bool = True
+
+
+@dataclass
+class WeightProfileSchema:
+    """Schema for entries under composite_profile_weights or standalone profiles/*."""
+
+    allow_nested: bool = True
+    require_non_negative: bool = True
+
+
+def _is_number(x: Any) -> bool:
+    return isinstance(x, (int, float)) and not isinstance(x, bool)
+
+
+def _validate_map(
+    m: Dict[str, Any],
+    allow_nested: bool,
+    require_non_negative: bool,
+    path: Tuple[str, ...] = (),
+    errors: List[str] | None = None,
+) -> List[str]:
+    errs: List[str] = [] if errors is None else errors
+    for k, v in m.items():
+        cur = path + (k,)
+        if isinstance(v, dict):
+            if not allow_nested:
+                errs.append(f"Nested mapping not allowed at {'.'.join(cur)}")
+            else:
+                _validate_map(v, allow_nested, require_non_negative, cur, errs)
+        else:
+            if not _is_number(v):
+                errs.append(
+                    f"Non-numeric weight at {'.'.join(cur)}: {type(v).__name__}"
+                )
+            elif require_non_negative and v < 0:
+                errs.append(f"Negative weight at {'.'.join(cur)}: {v}")
+    return errs
+
+
+def validate_weight_config(
+    cfg: Dict[str, Any], schema: WeightSchema | None = None
+) -> None:
+    sch = schema or WeightSchema()
+    errs = _validate_map(cfg, sch.allow_nested, sch.require_non_negative)
+    if errs:
+        for e in errs:
+            LOGGER.error("weight_validation_error", extra={"error": e})
+        emit_event("weights_validation_failed", {"errors": errs})
+        raise ValueError("Invalid weight config:\n" + "\n".join(errs))
+    LOGGER.info("weight_validation_ok", extra={"num_keys": len(cfg)})
+    emit_event("weights_validation_ok", {"num_keys": len(cfg)})
+
+
+def validate_profile_weights(
+    cfg: Dict[str, Any], schema: WeightProfileSchema | None = None
+) -> None:
+    sch = schema or WeightProfileSchema()
+    validate_weight_config(
+        cfg,
+        WeightSchema(
+            allow_nested=sch.allow_nested, require_non_negative=sch.require_non_negative
+        ),
+    )


### PR DESCRIPTION
## Summary
- implement full symbolic weights package with loader, validator, optimizer, logging utilities, and Typer CLI
- provide default and profile YAML weight sets plus smoke test
- add symbolic weight log files for event and text logging

## Testing
- `pre-commit run --files src/spectramind/symbolic/weights/__init__.py src/spectramind/symbolic/weights/loader.py src/spectramind/symbolic/weights/validator.py src/spectramind/symbolic/weights/auto_weight_optimizer.py src/spectramind/symbolic/weights/logging_utils.py src/spectramind/symbolic/weights/cli.py src/spectramind/symbolic/weights/README.md src/spectramind/symbolic/weights/_selftest.py src/spectramind/symbolic/weights/base_weights.yaml src/spectramind/symbolic/weights/molecule_region_weights.yaml src/spectramind/symbolic/weights/smoothness_penalty.yaml src/spectramind/symbolic/weights/nonnegativity_penalty.yaml src/spectramind/symbolic/weights/seam_continuity_penalty.yaml src/spectramind/symbolic/weights/quantile_monotonicity.yaml src/spectramind/symbolic/weights/composite_profile_weights.yaml src/spectramind/symbolic/weights/profiles/__init__.py src/spectramind/symbolic/weights/profiles/hot_jupiter.yaml src/spectramind/symbolic/weights/profiles/warm_neptune.yaml src/spectramind/symbolic/weights/profiles/super_earth.yaml src/spectramind/symbolic/weights/profiles/temperate_mini_neptune.yaml logs/symbolic_weights.log logs/symbolic_weights.events.jsonl`
- `pytest` (fails: ModuleNotFoundError: No module named 'torch')

------
https://chatgpt.com/codex/tasks/task_e_689f7947c520832a94bcf12d38162209