### PR TITLE
feat(cli): add full SpectraMind V50 CLI suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,8 @@ spectramind-logging-extras = [
     "mlflow>=2.14.0; python_version>='3.8'"
 ]
 
+[project.scripts]
+spectramind = "spectramind.cli.spectramind:main"
+
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/spectramind/cli/__init__.py
+++ b/src/spectramind/cli/__init__.py
@@ -1,1 +1,16 @@
+"""
+SpectraMind V50 — CLI package
+Provides Typer-based, mission-grade command-line interfaces for:
+    * Core training/inference/calibration/validation
+    * Diagnostics & dashboards
+    * Submission orchestration
+    * Ablation studies
+    * Guardrails, self-tests, and log analysis
 
+All commands:
+    * Initialize structured logging (console + RotatingFileHandler)
+    * Emit JSONL event stream to logs/events/cli_events.jsonl
+    * Append Markdown entries to logs/v50_debug_log.md
+    * Capture Git hash, config hash, runtime metadata
+    * Obey --dry-run and --confirm guardrails where appropriate
+"""

--- a/src/spectramind/cli/cli_ablate.py
+++ b/src/spectramind/cli/cli_ablate.py
@@ -1,0 +1,46 @@
+from typing import Optional
+
+import typer
+
+from .common import (
+    SRC_DIR,
+    logger,
+    ensure_tools,
+    command_session,
+    find_module_or_script,
+    call_python_module,
+    call_python_file,
+)
+
+app = typer.Typer(no_args_is_help=True, help="SpectraMind V50 — Symbolic-aware ablation engine")
+
+
+@app.command("run")
+def run(
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Base Hydra config"),
+    top_n: int = typer.Option(5, "--top-n", help="Export top-N leaderboard"),
+    md: bool = typer.Option(True, "--md/--no-md", help="Write Markdown leaderboard"),
+    open_html: bool = typer.Option(False, "--open-html/--no-open-html", help="Open HTML leaderboard after run"),
+):
+    """Execute auto_ablate_v50 with full diagnostics, symbolic scoring, and leaderboard export."""
+    ensure_tools()
+    args: list[str] = []
+    if config:
+        args += ["--config", config]
+    args += ["--top-n", str(top_n)]
+    if md:
+        args += ["--md"]
+    if open_html:
+        args += ["--open-html"]
+    with command_session("ablate.run", args):
+        module = "spectramind.auto_ablate_v50"
+        candidates = [SRC_DIR / "spectramind" / "auto_ablate_v50.py"]
+        k, s = find_module_or_script(module, candidates)
+        if k == "module":
+            rc = call_python_module(module, args)
+        elif k == "script" and s:
+            rc = call_python_file(s, args)
+        else:
+            logger.error("Missing auto_ablate_v50.")
+            raise typer.Exit(2)
+        raise typer.Exit(rc)

--- a/src/spectramind/cli/cli_bundle.py
+++ b/src/spectramind/cli/cli_bundle.py
@@ -1,0 +1,63 @@
+import json
+import shutil
+import zipfile
+from pathlib import Path
+from typing import Dict
+
+import typer
+
+from .common import (
+    PROJECT_ROOT,
+    REPORTS_DIR,
+    logger,
+    command_session,
+)
+
+app = typer.Typer(no_args_is_help=True, help="SpectraMind V50 — Bundle prediction & validator")
+
+REQUIRED_FILES = [
+    "predictions/mu.csv",
+    "predictions/sigma.csv",
+]
+
+def _manifest(bundle_dir: Path) -> Dict:
+    return {
+        "bundle_dir": str(bundle_dir),
+        "files": sorted([str(p.relative_to(PROJECT_ROOT)) for p in bundle_dir.rglob("*") if p.is_file()]),
+        "created": True,
+    }
+
+
+@app.command("make")
+def make(
+    preds_dir: str = typer.Option("predictions", "--preds"),
+    bundle_dir: str = typer.Option("submission_bundle", "--out"),
+    zip_name: str = typer.Option("submission.zip", "--zip"),
+):
+    """Bundle μ/σ predictions and artifacts into a submission directory and zip."""
+    with command_session("bundle.make", ["--preds", preds_dir, "--out", bundle_dir, "--zip", zip_name]):
+        p_preds = Path(preds_dir)
+        p_bundle = Path(bundle_dir)
+        p_bundle.mkdir(parents=True, exist_ok=True)
+        # Validate required files exist
+        for rf in REQUIRED_FILES:
+            f = PROJECT_ROOT / rf.replace("predictions", preds_dir)
+            if not f.exists():
+                logger.error("Missing required file: %s", f)
+                raise typer.Exit(2)
+        # Copy files
+        for src in p_preds.glob("*"):
+            if src.is_file():
+                shutil.copy2(src, p_bundle / src.name)
+        # Write manifest
+        manifest = REPORTS_DIR / "submission_manifest.json"
+        manifest.write_text(json.dumps(_manifest(p_bundle), indent=2), encoding="utf-8")
+        # Zip it
+        zip_path = Path(zip_name)
+        with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+            for p in sorted(p_bundle.rglob("*")):
+                if p.is_file():
+                    zf.write(p, p.relative_to(p_bundle))
+        logger.info("Bundle: %s", p_bundle)
+        logger.info("Zip: %s", zip_path)
+        raise typer.Exit(0)

--- a/src/spectramind/cli/cli_core_v50.py
+++ b/src/spectramind/cli/cli_core_v50.py
@@ -1,0 +1,166 @@
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+
+from .common import (
+    PROJECT_ROOT,
+    SRC_DIR,
+    REPORTS_DIR,
+    logger,
+    ensure_tools,
+    command_session,
+    find_module_or_script,
+    call_python_module,
+    call_python_file,
+    hydra_kv_to_cli,
+)
+from .cli_guardrails import dry_run_guard
+
+app = typer.Typer(no_args_is_help=True, help="SpectraMind V50 — Core commands: train, predict, calibrate, validate, explain.")
+
+
+def _cfg_list(config: Optional[str]) -> List[Path]:
+    paths: List[Path] = []
+    if config:
+        p = Path(config)
+        if p.exists():
+            paths.append(p)
+    return paths
+
+
+@app.command()
+@dry_run_guard
+def train(
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Hydra YAML config (config_v50.yaml)"),
+    overrides: List[str] = typer.Argument(None, help="Hydra overrides key=value"),
+    dry_run: bool = False,
+):
+    """Train SpectraMind V50 using Hydra config. Supports Hydra overrides: e.g. train epochs=50 optim.lr=3e-4"""
+    ensure_tools()
+    args = hydra_kv_to_cli(overrides or [])
+    with command_session("core.train", ["--config", str(config or ""), *args], _cfg_list(config)):
+        module = "spectramind.train_v50"
+        candidates = [SRC_DIR / "spectramind" / "train_v50.py"]
+        kind, script = find_module_or_script(module, candidates)
+        ret = 0
+        if kind == "module":
+            ret = call_python_module(module, (["--config", str(config)] + args) if config else args)
+        elif kind == "script" and script:
+            ret = call_python_file(script, (["--config", str(config)] + args) if config else args)
+        else:
+            logger.error("Missing training entrypoint (spectramind.train_v50).")
+            raise typer.Exit(2)
+        raise typer.Exit(ret)
+
+
+@app.command()
+@dry_run_guard
+def predict(
+    model_path: str = typer.Option(..., "--model", help="Path to trained model weights/checkpoint"),
+    outdir: str = typer.Option("predictions", "--outdir", help="Directory for predictions"),
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Optional Hydra config for inference"),
+    overrides: List[str] = typer.Argument(None, help="Hydra overrides key=value"),
+    dry_run: bool = False,
+):
+    """Run prediction to produce μ and σ spectra and artifacts for submission packaging."""
+    ensure_tools()
+    args = ["--model", model_path, "--outdir", outdir]
+    if config:
+        args += ["--config", config]
+    args += hydra_kv_to_cli(overrides or [])
+    with command_session("core.predict", args, _cfg_list(config)):
+        module = "spectramind.predict_v50"
+        candidates = [SRC_DIR / "spectramind" / "predict_v50.py"]
+        kind, script = find_module_or_script(module, candidates)
+        if kind == "module":
+            ret = call_python_module(module, args)
+        elif kind == "script" and script:
+            ret = call_python_file(script, args)
+        else:
+            logger.error("Missing prediction entrypoint (spectramind.predict_v50).")
+            raise typer.Exit(2)
+        raise typer.Exit(ret)
+
+
+@app.command()
+@dry_run_guard
+def calibrate(
+    preds_dir: str = typer.Option("predictions", "--preds", help="Directory with raw μ/σ"),
+    outdir: str = typer.Option("calibrated", "--outdir", help="Directory for calibrated outputs"),
+    method: str = typer.Option("corel", "--method", help="Calibration method: corel|temp|hybrid"),
+    dry_run: bool = False,
+):
+    """Calibrate predictive uncertainty (σ) using COREL / temperature scaling / hybrid methods."""
+    ensure_tools()
+    args = ["--preds", preds_dir, "--outdir", outdir, "--method", method]
+    with command_session("core.calibrate", args):
+        module = "spectramind.uncertainty.calibrate"
+        candidates = [SRC_DIR / "spectramind" / "uncertainty" / "calibrate.py"]
+        kind, script = find_module_or_script(module, candidates)
+        if kind == "module":
+            ret = call_python_module(module, args)
+        elif kind == "script" and script:
+            ret = call_python_file(script, args)
+        else:
+            logger.error("Missing calibrator (spectramind.uncertainty.calibrate).")
+            raise typer.Exit(2)
+        raise typer.Exit(ret)
+
+
+@app.command()
+@dry_run_guard
+def validate(
+    bundle_dir: str = typer.Option("submission_bundle", "--bundle", help="Submission directory to validate"),
+    dry_run: bool = False,
+):
+    """Validate submission bundle: file presence, GLL score evaluator, zips, and schema checks."""
+    ensure_tools()
+    args = ["--bundle", bundle_dir]
+    with command_session("core.validate", args):
+        module = "spectramind.validate_submission"
+        candidates = [SRC_DIR / "spectramind" / "validate_submission.py"]
+        kind, script = find_module_or_script(module, candidates)
+        if kind == "module":
+            ret = call_python_module(module, args)
+        elif kind == "script" and script:
+            ret = call_python_file(script, args)
+        else:
+            module2 = "spectramind.generate_diagnostic_summary"
+            cand2 = [SRC_DIR / "spectramind" / "generate_diagnostic_summary.py"]
+            k2, s2 = find_module_or_script(module2, cand2)
+            if k2 == "module":
+                ret = call_python_module(module2, ["--validate-bundle", bundle_dir])
+            elif k2 == "script" and s2:
+                ret = call_python_file(s2, ["--validate-bundle", bundle_dir])
+            else:
+                logger.error("No validator found.")
+                raise typer.Exit(2)
+        raise typer.Exit(ret)
+
+
+@app.command("explain")
+@dry_run_guard
+def explain_shap(
+    preds_dir: str = typer.Option("predictions", "--preds", help="Predictions directory for SHAP/metadata explain"),
+    outdir: str = typer.Option("explain", "--outdir", help="Output directory"),
+    dashboard: bool = typer.Option(True, "--dashboard/--no-dashboard", help="Generate interactive HTML dashboard"),
+    dry_run: bool = False,
+):
+    """Run SHAP + metadata + symbolic overlays and optionally generate a dashboard."""
+    ensure_tools()
+    args = ["--preds", preds_dir, "--outdir", outdir]
+    if dashboard:
+        args += ["--dashboard"]
+    with command_session("core.explain", args):
+        module = "spectramind.explain_shap_metadata_v50"
+        candidates = [SRC_DIR / "spectramind" / "explain_shap_metadata_v50.py"]
+        kind, script = find_module_or_script(module, candidates)
+        if kind == "module":
+            ret = call_python_module(module, args)
+        elif kind == "script" and script:
+            ret = call_python_file(script, args)
+        else:
+            logger.error("Missing explainer (explain_shap_metadata_v50).")
+            raise typer.Exit(2)
+        raise typer.Exit(ret)

--- a/src/spectramind/cli/cli_dashboard_mini.py
+++ b/src/spectramind/cli/cli_dashboard_mini.py
@@ -1,0 +1,41 @@
+from typing import Optional
+
+import typer
+
+from .common import (
+    SRC_DIR,
+    logger,
+    ensure_tools,
+    command_session,
+    find_module_or_script,
+    call_python_module,
+    call_python_file,
+    open_in_browser,
+)
+
+app = typer.Typer(no_args_is_help=True, help="SpectraMind V50 — Mini dashboard runner")
+
+
+@app.command("run")
+def run(
+    preds_dir: str = typer.Option("predictions", "--preds"),
+    out_html: str = typer.Option("reports/mini_dashboard.html", "--html"),
+    open_browser: bool = typer.Option(False, "--open-browser/--no-open-browser"),
+):
+    """Fast-path: generate diagnostic summary + HTML report in one go, optimized defaults."""
+    ensure_tools()
+    args = ["--preds", preds_dir, "--out", out_html]
+    with command_session("dashboard.mini", args):
+        module_html = "spectramind.generate_html_report"
+        cand_html = [SRC_DIR / "spectramind" / "generate_html_report.py"]
+        k, s = find_module_or_script(module_html, cand_html)
+        if k == "module":
+            rc = call_python_module(module_html, ["--quick", "--preds", preds_dir, "--html-out", out_html])
+        elif k == "script" and s:
+            rc = call_python_file(s, ["--quick", "--preds", preds_dir, "--html-out", out_html])
+        else:
+            logger.error("Missing generate_html_report.")
+            raise typer.Exit(2)
+        if rc == 0 and open_browser:
+            open_in_browser(out_html)
+        raise typer.Exit(rc)

--- a/src/spectramind/cli/cli_diagnose.py
+++ b/src/spectramind/cli/cli_diagnose.py
@@ -1,0 +1,86 @@
+from pathlib import Path
+from typing import Optional
+
+import typer
+
+from .common import (
+    PROJECT_ROOT,
+    SRC_DIR,
+    REPORTS_DIR,
+    logger,
+    ensure_tools,
+    command_session,
+    find_module_or_script,
+    call_python_module,
+    call_python_file,
+    open_in_browser,
+)
+
+app = typer.Typer(no_args_is_help=True, help="SpectraMind V50 — Diagnostics & Dashboard")
+
+
+@app.command("dashboard")
+def dashboard(
+    preds_dir: str = typer.Option("predictions", "--preds", help="Predictions directory"),
+    outdir: str = typer.Option("diagnostics", "--outdir", help="Diagnostics output directory"),
+    html_out: str = typer.Option("reports/diagnostic_report_v1.html", "--html-out"),
+    open_browser: bool = typer.Option(False, "--open-browser/--no-open-browser"),
+    no_umap: bool = typer.Option(False, "--no-umap", help="Skip UMAP render"),
+    no_tsne: bool = typer.Option(False, "--no-tsne", help="Skip t-SNE render"),
+):
+    """Build unified diagnostics: GLL heatmap, UMAP/t-SNE, SHAP overlays, symbolic rule leaderboard,
+    COREL calibration plots, and an interactive HTML dashboard."""
+    ensure_tools()
+    args_summary = ["--preds", preds_dir, "--outdir", outdir, "--emit-json"]
+    with command_session("diagnose.dashboard", ["--preds", preds_dir, "--outdir", outdir, "--html", html_out]):
+        module_sum = "spectramind.generate_diagnostic_summary"
+        cand_sum = [SRC_DIR / "spectramind" / "generate_diagnostic_summary.py"]
+        k, s = find_module_or_script(module_sum, cand_sum)
+        if k == "module":
+            rc = call_python_module(module_sum, args_summary)
+        elif k == "script" and s:
+            rc = call_python_file(s, args_summary)
+        else:
+            logger.error("Missing generate_diagnostic_summary.")
+            raise typer.Exit(2)
+        if rc != 0:
+            raise typer.Exit(rc)
+        module_html = "spectramind.generate_html_report"
+        cand_html = [SRC_DIR / "spectramind" / "generate_html_report.py"]
+        args_html = ["--preds", preds_dir, "--diagnostics", outdir, "--html-out", html_out]
+        if no_umap:
+            args_html.append("--no-umap")
+        if no_tsne:
+            args_html.append("--no-tsne")
+        k2, s2 = find_module_or_script(module_html, cand_html)
+        if k2 == "module":
+            rc2 = call_python_module(module_html, args_html)
+        elif k2 == "script" and s2:
+            rc2 = call_python_file(s2, args_html)
+        else:
+            logger.error("Missing generate_html_report.")
+            raise typer.Exit(2)
+        if rc2 == 0 and open_browser:
+            open_in_browser(html_out)
+        raise typer.Exit(rc2)
+
+
+@app.command("gll-heatmap")
+def gll_heatmap(
+    preds_dir: str = typer.Option("predictions", "--preds", help="Predictions directory"),
+    outdir: str = typer.Option("diagnostics", "--outdir", help="Diagnostics output directory"),
+):
+    """Render bin-wise GLL heatmap and summary."""
+    ensure_tools()
+    with command_session("diagnose.gll-heatmap", ["--preds", preds_dir, "--outdir", outdir]):
+        module = "spectramind.plot_gll_heatmap_per_bin"
+        candidates = [SRC_DIR / "spectramind" / "plot_gll_heatmap_per_bin.py"]
+        k, s = find_module_or_script(module, candidates)
+        if k == "module":
+            rc = call_python_module(module, ["--preds", preds_dir, "--outdir", outdir])
+        elif k == "script" and s:
+            rc = call_python_file(s, ["--preds", preds_dir, "--outdir", outdir])
+        else:
+            logger.error("Missing plot_gll_heatmap_per_bin.")
+            raise typer.Exit(2)
+        raise typer.Exit(rc)

--- a/src/spectramind/cli/cli_guardrails.py
+++ b/src/spectramind/cli/cli_guardrails.py
@@ -1,0 +1,36 @@
+import os
+import sys
+from functools import wraps
+from pathlib import Path
+from typing import Callable, Optional
+
+from .common import logger
+
+def confirm_guard(prompt: str = "Proceed? [y/N]: "):
+    def deco(fn: Callable):
+        @wraps(fn)
+        def inner(*args, confirm: bool = False, **kwargs):
+            if not confirm:
+                resp = os.environ.get("SPECTRAMIND_CONFIRM", "").lower() or input(prompt).strip().lower()
+                if resp not in ("y", "yes"):
+                    logger.info("Aborted by user.")
+                    sys.exit(1)
+            return fn(*args, **kwargs)
+        return inner
+    return deco
+
+
+def dry_run_guard(fn: Callable):
+    @wraps(fn)
+    def inner(*args, dry_run: bool = False, **kwargs):
+        if dry_run:
+            logger.info("[DRY-RUN] Command validated, not executing actions.")
+            return 0
+        return fn(*args, **kwargs)
+    return inner
+
+
+def require_file(path: Path, desc: Optional[str] = None):
+    if not path.exists():
+        logger.error("Missing %s: %s", desc or "file", path)
+        sys.exit(2)

--- a/src/spectramind/cli/cli_submit.py
+++ b/src/spectramind/cli/cli_submit.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from typing import List, Optional
+
+import typer
+
+from .common import (
+    SRC_DIR,
+    logger,
+    ensure_tools,
+    command_session,
+    find_module_or_script,
+    call_python_module,
+    call_python_file,
+)
+
+app = typer.Typer(no_args_is_help=True, help="SpectraMind V50 — End-to-end submission orchestration")
+
+
+@app.command("make-submission")
+def make_submission(
+    model_path: str = typer.Option(..., "--model", help="Trained checkpoint"),
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Hydra config"),
+    outdir: str = typer.Option("submission_bundle", "--out", help="Submission output dir"),
+    run_selftest: bool = typer.Option(True, "--selftest/--no-selftest"),
+):
+    """Pipeline:
+    1) selftest
+    2) predict
+    3) calibrate (COREL default)
+    4) validate
+    5) bundle zip"""
+    ensure_tools()
+    with command_session("submit.make-submission", ["--model", model_path, "--out", outdir]):
+        if run_selftest:
+            from .selftest import cli as selftest_cli
+            rc = selftest_cli("fast")
+            if rc != 0:
+                raise typer.Exit(rc)
+        module_pred = "spectramind.predict_v50"
+        cand_pred = [SRC_DIR / "spectramind" / "predict_v50.py"]
+        pred_args: List[str] = ["--model", model_path, "--outdir", "predictions"]
+        if config:
+            pred_args += ["--config", config]
+        k, s = find_module_or_script(module_pred, cand_pred)
+        if k == "module":
+            rc2 = call_python_module(module_pred, pred_args)
+        elif k == "script" and s:
+            rc2 = call_python_file(s, pred_args)
+        else:
+            logger.error("Missing predict_v50.")
+            raise typer.Exit(2)
+        if rc2 != 0:
+            raise typer.Exit(rc2)
+        module_cal = "spectramind.uncertainty.calibrate"
+        cand_cal = [SRC_DIR / "spectramind" / "uncertainty" / "calibrate.py"]
+        k3, s3 = find_module_or_script(module_cal, cand_cal)
+        if k3 == "module":
+            rc3 = call_python_module(module_cal, ["--preds", "predictions", "--outdir", "calibrated", "--method", "corel"])
+        elif k3 == "script" and s3:
+            rc3 = call_python_file(s3, ["--preds", "predictions", "--outdir", "calibrated", "--method", "corel"])
+        else:
+            logger.warning("Calibrator not found; skipping calibration step.")
+            rc3 = 0
+        if rc3 != 0:
+            raise typer.Exit(rc3)
+        module_val = "spectramind.validate_submission"
+        cand_val = [SRC_DIR / "spectramind" / "validate_submission.py"]
+        k4, s4 = find_module_or_script(module_val, cand_val)
+        val_args = ["--bundle", outdir]
+        if k4 == "module":
+            rc4 = call_python_module(module_val, val_args)
+        elif k4 == "script" and s4:
+            rc4 = call_python_file(s4, val_args)
+        else:
+            logger.warning("Validator not found; relying on bundler-level checks.")
+            rc4 = 0
+        if rc4 != 0:
+            raise typer.Exit(rc4)
+        from .cli_bundle import make as bundle_make
+        rc5 = bundle_make(
+            preds_dir="calibrated" if k3 != "missing" else "predictions",
+            bundle_dir=outdir,
+            zip_name="submission.zip",
+        )
+        raise typer.Exit(rc5 if isinstance(rc5, int) else 0)

--- a/src/spectramind/cli/common.py
+++ b/src/spectramind/cli/common.py
@@ -1,0 +1,291 @@
+import hashlib
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+
+# --- Constants
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+LOG_DIR = PROJECT_ROOT / "logs"
+EVENTS_DIR = LOG_DIR / "events"
+REPORTS_DIR = PROJECT_ROOT / "reports"
+DIAG_DIR = PROJECT_ROOT / "diagnostics"
+SRC_DIR = PROJECT_ROOT / "src"
+PKG_DIR = SRC_DIR / "spectramind"
+CLI_DIR = PKG_DIR / "cli"
+DEFAULT_EVENT_JSONL = EVENTS_DIR / "cli_events.jsonl"
+MD_LOG = LOG_DIR / "v50_debug_log.md"
+ROTATING_LOG = LOG_DIR / "cli.log"
+ROTATE_BYTES = 10 * 1024 * 1024
+ROTATE_BACKUPS = 5
+CLI_VERSION = "v50.2025.08.15"
+
+# --- FS ensure
+for p in [LOG_DIR, EVENTS_DIR, REPORTS_DIR, DIAG_DIR]:
+    p.mkdir(parents=True, exist_ok=True)
+
+# --- Logging setup
+_LOGGER: Optional[logging.Logger] = None
+
+def init_logging(name: str = "spectramind.cli", level: int = logging.INFO) -> logging.Logger:
+    global _LOGGER
+    if _LOGGER is not None:
+        return _LOGGER
+    logger = logging.getLogger(name)
+    logger.setLevel(level)
+    logger.propagate = False
+    # Console
+    ch = logging.StreamHandler(sys.stdout)
+    ch.setLevel(level)
+    ch.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s - %(message)s", "%H:%M:%S"))
+    logger.addHandler(ch)
+    # Rotating file
+    fh = RotatingFileHandler(ROTATING_LOG, maxBytes=ROTATE_BYTES, backupCount=ROTATE_BACKUPS)
+    fh.setLevel(level)
+    fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(fh)
+    _LOGGER = logger
+    return logger
+
+
+logger = init_logging()
+
+# --- Utilities
+
+def _read_text_safe(p: Path) -> str:
+    try:
+        return p.read_text(encoding="utf-8")
+    except Exception:
+        return ""
+
+
+def git_info() -> Dict[str, str]:
+    info = {"git_commit": "unknown", "git_branch": "unknown", "git_dirty": "unknown"}
+    try:
+        commit = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=PROJECT_ROOT).decode().strip()
+        info["git_commit"] = commit
+    except Exception:
+        pass
+    try:
+        branch = subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"], cwd=PROJECT_ROOT).decode().strip()
+        info["git_branch"] = branch
+    except Exception:
+        pass
+    try:
+        status = subprocess.check_output(["git", "status", "--porcelain"], cwd=PROJECT_ROOT).decode()
+        info["git_dirty"] = "dirty" if status.strip() else "clean"
+    except Exception:
+        pass
+    return info
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def sha256_string(s: str) -> str:
+    return hashlib.sha256(s.encode("utf-8")).hexdigest()
+
+
+def config_hash(paths: Iterable[Union[str, Path]]) -> str:
+    parts: List[str] = []
+    for p in paths:
+        p = Path(p)
+        if p.is_file():
+            parts.append(f"{p.name}:{sha256_file(p)}")
+        elif p.is_dir():
+            for sub in sorted(p.rglob("*")):
+                if sub.is_file():
+                    parts.append(f"{sub.relative_to(p)}:{sha256_file(sub)}")
+        else:
+            parts.append(f"{p}:missing")
+    digest = sha256_string("|".join(parts)) if parts else sha256_string("none")
+    return digest[:12]
+
+
+def write_jsonl_event(event_type: str, payload: Dict[str, Any], jsonl_path: Path = DEFAULT_EVENT_JSONL) -> None:
+    rec = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": event_type,
+        **payload,
+    }
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    with jsonl_path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+
+def append_markdown_log(
+    command: str,
+    args: List[str],
+    cli_version: str,
+    cfg_hash: str,
+    status: str,
+    started_at: float,
+    finished_at: float,
+    extras: Optional[Dict[str, Any]] = None,
+) -> None:
+    gi = git_info()
+    host = platform.node()
+    md = []
+    md.append(f"### {datetime.now().isoformat()} — {command} status: {status}")
+    md.append("")
+    md.append(f"- CLI Version: {cli_version}")
+    md.append(f"- Host: {host}")
+    md.append(f"- Git: {gi.get('git_branch','?')} @ {gi.get('git_commit','?')} ({gi.get('git_dirty','?')})")
+    md.append(f"- Config Hash: {cfg_hash}")
+    md.append(f"- Args: {' '.join(args)}")
+    md.append(f"- Duration: {finished_at - started_at:.2f}s")
+    if extras:
+        for k, v in extras.items():
+            md.append(f"- {k}: {v}")
+    md.append("")
+    md_log = "\n".join(md) + "\n"
+    with MD_LOG.open("a", encoding="utf-8") as f:
+        f.write(md_log)
+
+
+def capture_env_snapshot(out_dir: Path) -> Dict[str, str]:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    snaps: Dict[str, str] = {}
+    # pip freeze
+    try:
+        pf = subprocess.check_output([sys.executable, "-m", "pip", "freeze"]).decode()
+        (out_dir / "pip-freeze.txt").write_text(pf, encoding="utf-8")
+        snaps["pip_freeze"] = str((out_dir / "pip-freeze.txt").relative_to(PROJECT_ROOT))
+    except Exception:
+        pass
+    # conda
+    try:
+        ci = subprocess.check_output(["conda", "env", "export"]).decode()
+        (out_dir / "conda-env.yaml").write_text(ci, encoding="utf-8")
+        snaps["conda_env"] = str((out_dir / "conda-env.yaml").relative_to(PROJECT_ROOT))
+    except Exception:
+        pass
+    # nvidia-smi
+    try:
+        smi = subprocess.check_output(["nvidia-smi"]).decode()
+        (out_dir / "nvidia-smi.txt").write_text(smi, encoding="utf-8")
+        snaps["nvidia_smi"] = str((out_dir / "nvidia-smi.txt").relative_to(PROJECT_ROOT))
+    except Exception:
+        pass
+    # python env
+    (out_dir / "python.txt").write_text(sys.version, encoding="utf-8")
+    snaps["python"] = str((out_dir / "python.txt").relative_to(PROJECT_ROOT))
+    return snaps
+
+
+def hydra_kv_to_cli(overrides: List[str]) -> List[str]:
+    # Normalize Hydra-like overrides (key=value) preserving pass-through CLI tokens
+    out: List[str] = []
+    for o in overrides:
+        if "=" in o and not o.strip().startswith("--"):
+            out.append(f"+{o}")
+        else:
+            out.append(o)
+    return out
+
+
+def open_in_browser(path: Union[str, Path]) -> None:
+    try:
+        import webbrowser
+        webbrowser.open_new_tab(str(path))
+    except Exception:
+        logger.warning("Failed to open browser for %s", path)
+
+
+def call_python_module(mod: str, args: List[str]) -> int:
+    cmd = [sys.executable, "-m", mod] + args
+    logger.info("Exec: %s", " ".join(cmd))
+    return subprocess.call(cmd, cwd=PROJECT_ROOT)
+
+
+def call_python_file(py_file: Path, args: List[str]) -> int:
+    cmd = [sys.executable, str(py_file)] + args
+    logger.info("Exec: %s", " ".join(cmd))
+    return subprocess.call(cmd, cwd=PROJECT_ROOT)
+
+
+def find_module_or_script(module: str, candidates: List[Path]) -> Tuple[str, Optional[Path]]:
+    """
+    Returns ("module", None) if importable, else ("script", path) if file exists, else ("missing", None)
+    """
+    try:
+        import importlib
+        importlib.import_module(module)
+        return ("module", None)
+    except Exception:
+        for c in candidates:
+            if c.exists():
+                return ("script", c)
+        return ("missing", None)
+
+
+@contextmanager
+def command_session(command: str, args: List[str], cfg_paths: Optional[List[Union[str, Path]]] = None):
+    started = time.time()
+    cfg_hash = config_hash(cfg_paths or [])
+    write_jsonl_event("cli_start", {
+        "command": command,
+        "args": args,
+        "cli_version": CLI_VERSION,
+        "config_hash": cfg_hash,
+        "git": git_info(),
+    })
+    status = "success"
+    err: Optional[str] = None
+    try:
+        yield cfg_hash, started
+    except SystemExit as se:  # propagate but log
+        status = f"system_exit({getattr(se, 'code', 0)})"
+        err = None
+        raise
+    except Exception as e:
+        status = "error"
+        err = "".join(traceback.format_exception(e))
+        raise
+    finally:
+        finished = time.time()
+        extras = {"error": err[:2000]} if err else None
+        append_markdown_log(command, args, CLI_VERSION, cfg_hash, status, started, finished, extras=extras)
+        write_jsonl_event("cli_finish", {
+            "command": command,
+            "status": status,
+            "duration_sec": finished - started,
+            "config_hash": cfg_hash,
+        })
+
+
+def ensure_tools():
+    # Helpful runtime checks
+    try:
+        import typer  # noqa: F401
+    except Exception as e:
+        logger.error("Typer not installed. pip install typer[all]  (%s)", e)
+        sys.exit(2)
+
+
+def md_table(rows: List[List[str]]) -> str:
+    if not rows:
+        return ""
+    widths = [max(len(r[i]) for r in rows) for i in range(len(rows[0]))]
+
+    def fmt_line(r: List[str]) -> str:
+        return "| " + " | ".join((c + " " * (widths[i] - len(c))) for i, c in enumerate(r)) + " |"
+
+    lines = [fmt_line(rows[0]), "| " + " | ".join("-" * w for w in widths) + " |"]
+    lines += [fmt_line(r) for r in rows[1:]]
+    return "\n".join(lines)

--- a/src/spectramind/cli/selftest.py
+++ b/src/spectramind/cli/selftest.py
@@ -1,0 +1,99 @@
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+from .common import (
+    PROJECT_ROOT,
+    SRC_DIR,
+    PKG_DIR,
+    CLI_DIR,
+    LOG_DIR,
+    REPORTS_DIR,
+    DIAG_DIR,
+    logger,
+    capture_env_snapshot,
+    write_jsonl_event,
+    md_table,
+    command_session,
+)
+
+REQUIRED_PATHS = [
+    SRC_DIR / "spectramind",
+    PKG_DIR / "__init__.py",
+]
+
+RECOMMENDED_FILES = [
+    PROJECT_ROOT / "config_v50.yaml",
+    PROJECT_ROOT / "README.md",
+]
+
+OPTIONAL_SCRIPTS = [
+    SRC_DIR / "spectramind" / "train_v50.py",
+    SRC_DIR / "spectramind" / "predict_v50.py",
+    SRC_DIR / "spectramind" / "generate_html_report.py",
+    SRC_DIR / "spectramind" / "generate_diagnostic_summary.py",
+]
+
+def run_selftest(mode: str = "fast") -> Dict[str, str]:
+    status: Dict[str, str] = {}
+    # Basic structure checks
+    for p in REQUIRED_PATHS:
+        status[str(p.relative_to(PROJECT_ROOT))] = "ok" if p.exists() else "missing"
+    # Recommended
+    for p in RECOMMENDED_FILES:
+        status[str(p.relative_to(PROJECT_ROOT))] = "ok" if p.exists() else "missing"
+    # Optional scripts
+    for p in OPTIONAL_SCRIPTS:
+        status[str(p.relative_to(PROJECT_ROOT))] = "ok" if p.exists() else "missing"
+    # Import tests
+    if mode != "deep":
+        try:
+            import typer  # noqa: F401
+            status["python.typer"] = "ok"
+        except Exception as e:
+            status["python.typer"] = f"fail:{e}"
+    else:
+        modules = [
+            "spectramind.train_v50",
+            "spectramind.predict_v50",
+            "spectramind.generate_html_report",
+            "spectramind.generate_diagnostic_summary",
+        ]
+        for m in modules:
+            try:
+                __import__(m)
+                status[f"import.{m}"] = "ok"
+            except Exception as e:
+                status[f"import.{m}"] = f"fail:{e}"
+    return status
+
+
+def write_reports(status: Dict[str, str]) -> None:
+    # JSON
+    rep_json = REPORTS_DIR / "selftest_report.json"
+    rep_json.write_text(json.dumps(status, indent=2), encoding="utf-8")
+    # Markdown table
+    rows = [["Item", "Status"]] + [[k, v] for k, v in sorted(status.items())]
+    md = "# SpectraMind V50 — Selftest Report\n\n" + md_table(rows) + "\n"
+    (REPORTS_DIR / "selftest_report.md").write_text(md, encoding="utf-8")
+    logger.info("Wrote: %s", rep_json)
+    logger.info("Wrote: %s", REPORTS_DIR / "selftest_report.md")
+
+
+def cli(mode: str = "fast") -> int:
+    with command_session("selftest", [f"--mode={mode}"]):
+        status = run_selftest(mode=mode)
+        write_reports(status)
+        envdir = REPORTS_DIR / "env"
+        snaps = capture_env_snapshot(envdir)
+        write_jsonl_event("selftest_done", {"mode": mode, "status": status, "env": snaps})
+        ok = all(v == "ok" for v in status.values() if not v.startswith("fail"))
+        return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    m = "fast"
+    if len(sys.argv) > 1 and sys.argv[1].startswith("--mode="):
+        m = sys.argv[1].split("=", 1)[1]
+    sys.exit(cli(m))

--- a/src/spectramind/cli/spectramind.py
+++ b/src/spectramind/cli/spectramind.py
@@ -1,76 +1,177 @@
-from __future__ import annotations
-
 import json
 import os
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
 from typing import Optional
 
 import typer
 
-from ..conf_helpers.hashing import config_hash
-from ..train.trainer import train_v50
-from ..utils.git_env import capture_git_env
-from ..utils.hydra_safe import load_yaml
-from ..utils.logging_setup import build_logger, log_event
+from .common import (
+    CLI_VERSION,
+    PROJECT_ROOT,
+    LOG_DIR,
+    EVENTS_DIR,
+    REPORTS_DIR,
+    logger,
+    command_session,
+    git_info,
+    config_hash,
+    md_table,
+)
+from . import selftest as selftest_mod
+from . import cli_core_v50 as core
+from . import cli_diagnose as diag
+from . import cli_submit as submit
+from . import cli_ablate as ablate
+from . import cli_bundle as bundle
+from . import cli_dashboard_mini as dashmini
 
-app = typer.Typer(help="SpectraMind V50 — Unified CLI")
+app = typer.Typer(add_completion=True, no_args_is_help=True, help="SpectraMind V50 — Unified CLI")
+
+# Register sub-apps
+app.add_typer(core.app, name="core", help="Core train/predict/calibrate/validate/explain")
+app.add_typer(diag.app, name="diagnose", help="Diagnostics and dashboard")
+app.add_typer(submit.app, name="submit", help="Submission orchestration")
+app.add_typer(ablate.app, name="ablate", help="Symbolic-aware ablations")
+app.add_typer(bundle.app, name="bundle", help="Packaging/bundling")
+app.add_typer(dashmini.app, name="dashboard-mini", help="Quick report builder")
 
 
-@app.command()
-def version() -> None:
-    logger, jsonl, _ = build_logger()
-    meta = capture_git_env()
-    log_event(jsonl, "cli.version", {"meta": meta})
-    print(json.dumps({"version": "v50-cli", **meta}, indent=2))
+@app.command("version")
+def version(
+    cfg: Optional[str] = typer.Option(None, "--config", "-c", help="Optional config file to hash"),
+):
+    """Print CLI version, git info, and optional config hash; log to v50_debug_log.md and JSONL stream."""
+    args = ["--config", cfg] if cfg else []
+    with command_session("cli.version", args, [cfg] if cfg else None):
+        gi = git_info()
+        ch = config_hash([cfg]) if cfg else "none"
+        info = {
+            "cli_version": CLI_VERSION,
+            "git": gi,
+            "config_hash": ch,
+            "timestamp": datetime.utcnow().isoformat() + "Z",
+        }
+        typer.echo(json.dumps(info, indent=2))
 
 
-@app.command()
-def train(config: str = typer.Option(..., help="Path to config_v50.yaml")) -> None:
-    cfg = load_yaml(config)
-    cfg["_config_hash"] = config_hash(cfg)
-    out = train_v50(cfg)
-    print(json.dumps({"status": "ok", **out}, indent=2))
+@app.command("test")
+def test(
+    mode: str = typer.Option("fast", "--mode", help="fast|deep"),
+):
+    """Run selftest (pipeline/CLI integrity, presence, env snapshot)."""
+    rc = selftest_mod.cli(mode=mode)
+    raise typer.Exit(rc)
 
 
-@app.command()
+@app.command("analyze-log")
 def analyze_log(
-    log_jsonl: str = typer.Option(
-        "logs/spectramind_v50.jsonl", help="Path to JSONL event stream"
-    ),
-    out_md: Optional[str] = typer.Option(None, help="Optional Markdown summary path"),
-) -> None:
-    from collections import Counter
+    path: str = typer.Option(str(LOG_DIR / "v50_debug_log.md"), "--path", help="Path to MD log"),
+    out_md: str = typer.Option(str(REPORTS_DIR / "log_table.md"), "--out-md"),
+    out_csv: str = typer.Option(str(REPORTS_DIR / "log_table.csv"), "--out-csv"),
+    clean: bool = typer.Option(False, "--clean/--no-clean", help="Deduplicate repeated entries"),
+):
+    """Parse v50_debug_log.md into a Markdown/CSV table. Optionally deduplicate."""
+    with command_session("cli.analyze-log", ["--path", path, "--out-md", out_md, "--out-csv", out_csv, "--clean", str(clean)]):
+        p = Path(path)
+        if not p.exists():
+            typer.echo("Log not found.")
+            raise typer.Exit(2)
+        text = p.read_text(encoding="utf-8").splitlines()
+        entries = []
+        cur: dict[str, str] = {}
+        for line in text:
+            if line.startswith("### ") and " — " in line and "status:" in line:
+                if cur:
+                    entries.append(cur)
+                    cur = {}
+                ts = line.split("### ")[1].split(" — ")[0].strip()
+                status_match = re.search(r"status:\s+(\S+)", line)
+                cur = {"ts": ts, "status": status_match.group(1) if status_match else "?"}
+            elif line.strip().startswith("- "):
+                k, _, v = line.strip()[2:].partition(":")
+                cur[k.strip()] = v.strip().strip("`")
+        if cur:
+            entries.append(cur)
+        if clean:
+            seen = set()
+            deduped = []
+            for e in entries:
+                key = (e.get("CLI Version", ""), e.get("Git", ""), e.get("Args", ""), e.get("Config Hash", ""))
+                if key in seen:
+                    continue
+                seen.add(key)
+                deduped.append(e)
+            entries = deduped
+        rows = [["ts", "status", "CLI Version", "Git", "Config Hash", "Args", "Duration"]]
+        for e in entries:
+            rows.append([
+                e.get("ts", ""),
+                e.get("status", ""),
+                e.get("CLI Version", ""),
+                e.get("Git", ""),
+                e.get("Config Hash", ""),
+                e.get("Args", ""),
+                e.get("Duration", ""),
+            ])
+        md = "# CLI Log Table\n\n" + md_table(rows) + "\n"
+        Path(out_md).write_text(md, encoding="utf-8")
+        import csv
 
-    n = 0
-    kinds = Counter()
-    if not os.path.exists(log_jsonl):
-        print(json.dumps({"error": "missing log file", "path": log_jsonl}, indent=2))
-        raise typer.Exit(code=1)
-    with open(log_jsonl, "r", encoding="utf-8") as fh:
-        for line in fh:
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                ev = (
-                    json.loads(line.split(" | ", 3)[-1])
-                    if " | " in line
-                    else json.loads(line)
-                )
-                kinds[ev.get("kind", "unknown")] += 1
-                n += 1
-            except Exception:
-                pass
-    summary = {"total_events": n, "by_kind": kinds.most_common()}
-    print(json.dumps(summary, indent=2))
-    if out_md:
-        os.makedirs(os.path.dirname(out_md), exist_ok=True)
-        with open(out_md, "w", encoding="utf-8") as fh:
-            fh.write("# SpectraMind V50 — Log Summary\n\n")
-            fh.write(f"- Total events: {n}\n\n")
-            fh.write("| Kind | Count |\n|---|---:|\n")
-            for k, c in kinds.most_common():
-                fh.write(f"| {k} | {c} |\n")
+        with open(out_csv, "w", newline="", encoding="utf-8") as f:
+            w = csv.writer(f)
+            w.writerow(rows[0])
+            for r in rows[1:]:
+                w.writerow(r)
+        typer.echo(f"Wrote {out_md}\nWrote {out_csv}")
+
+
+@app.command("corel-train")
+def corel_train(
+    config: Optional[str] = typer.Option(None, "--config", "-c", help="Hydra config"),
+):
+    """Train COREL GNN calibrator if available in repo."""
+    from .common import find_module_or_script, call_python_module, call_python_file
+
+    with command_session("cli.corel-train", ["--config", str(config or "")], [config] if config else None):
+        module = "spectramind.corel.train_corel"
+        candidates = [SRC_DIR / "spectramind" / "corel" / "train_corel.py"]
+        k, s = find_module_or_script(module, candidates)
+        args = ["--config", config] if config else []
+        if k == "module":
+            rc = call_python_module(module, args)
+        elif k == "script" and s:
+            rc = call_python_file(s, args)
+        else:
+            typer.echo("train_corel not found.")
+            raise typer.Exit(2)
+        raise typer.Exit(rc)
+
+
+@app.command("check-cli-map")
+def check_cli_map():
+    """Dump/validate command-to-file mapping via existing utility if present."""
+    from .common import find_module_or_script, call_python_module, call_python_file
+
+    with command_session("cli.check-cli-map", []):
+        module = "spectramind.cli_explain_util"
+        candidates = [SRC_DIR / "spectramind" / "cli_explain_util.py"]
+        k, s = find_module_or_script(module, candidates)
+        if k == "module":
+            rc = call_python_module(module, [])
+        elif k == "script" and s:
+            rc = call_python_file(s, [])
+        else:
+            typer.echo("cli_explain_util not found.")
+            raise typer.Exit(2)
+        raise typer.Exit(rc)
+
+
+def main():
+    app()
 
 
 if __name__ == "__main__":
-    app()
+    main()


### PR DESCRIPTION
## Summary
- introduce `spectramind.cli` package with common logging utilities and guardrails
- add core, diagnostics, ablation, bundling, dashboard, and submission CLIs
- expose `spectramind` script entrypoint in `pyproject.toml`

## Testing
- `pytest` *(fails: No module named 'torch')*
- `pip install torch --extra-index-url https://download.pytorch.org/whl/cpu` *(HTTP 403, proxy prevented download)*

------
https://chatgpt.com/codex/tasks/task_e_689f82954ec0832a927797b6898b96e6