### PR TITLE
Configure Hydra job logging

### DIFF
--- a/conf/hydra/job_logging/custom.yaml
+++ b/conf/hydra/job_logging/custom.yaml
@@ -1,7 +1,61 @@
-# Use our dictConfig and avoid Hydra reconfiguring root handlers.
+# Hydra job_logging configuration for SpectraMind V50
+# This sets up console logging, rotating file logging, and optional JSONL for structured logs.
+
 version: 1
-formatters: {}
-handlers: {}
+formatters:
+  standard:
+    format: "[%(asctime)s][%(levelname)s][%(name)s] %(message)s"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+  debug:
+    format: "[%(asctime)s][%(levelname)s][%(name)s:%(lineno)d] %(message)s"
+    datefmt: "%Y-%m-%d %H:%M:%S"
+  jsonl:
+    format: '{"time": "%(asctime)s", "level": "%(levelname)s", "logger": "%(name)s", "message": "%(message)s"}'
+    datefmt: "%Y-%m-%dT%H:%M:%S"
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    formatter: standard
+    level: INFO
+    stream: ext://sys.stdout
+  console_debug:
+    class: logging.StreamHandler
+    formatter: debug
+    level: DEBUG
+    stream: ext://sys.stdout
+  rotating_file:
+    class: logging.handlers.RotatingFileHandler
+    formatter: standard
+    level: DEBUG
+    filename: logs/spectramind_v50.log
+    maxBytes: 5242880  # 5MB
+    backupCount: 5
+    encoding: utf8
+  jsonl_file:
+    class: logging.handlers.RotatingFileHandler
+    formatter: jsonl
+    level: DEBUG
+    filename: logs/spectramind_v50.jsonl
+    maxBytes: 10485760  # 10MB
+    backupCount: 3
+    encoding: utf8
+
 root:
-  handlers: []
+  level: DEBUG
+  handlers: [console, rotating_file, jsonl_file]
+
+loggers:
+  # Hydra’s own logger
+  hydra:
+    level: WARNING
+    handlers: [console]
+    propagate: no
+  # Project-level logger
+  spectramind:
+    level: DEBUG
+    handlers: [console, rotating_file, jsonl_file]
+    propagate: no
+
+disable_existing_loggers: false
 


### PR DESCRIPTION
## Summary
- configure Hydra job logging with console, rotating file, and JSONL handlers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_689fceec098c832abd8d86bea4bfe54b