### PR TITLE
Add SpectraMind V50 calibration step sequence defaults

### DIFF
--- a/configs/calibration/steps/default.yaml
+++ b/configs/calibration/steps/default.yaml
@@ -1,0 +1,68 @@
+# Hydra configuration for SpectraMind V50 calibration step sequencing
+# This file defines the default calibration pipeline execution order and parameters.
+
+# @package _group_
+# This group defines the ordered list of calibration steps for the SpectraMind V50 pipeline.
+# Each step can be overridden via CLI or experiment-specific configs.
+# All steps are executed in the listed order unless explicitly skipped.
+
+defaults:
+  - _self_
+  - step_definitions: default  # Loads the parameter templates for each calibration step.
+
+# Ordered list of calibration steps to run
+steps:
+  - name: raw_ingest
+    enabled: true
+    description: "Ingest raw FGS1/AIRS frames from the dataset into the processing pipeline."
+    params: ${calibration/step_definitions/raw_ingest}
+
+  - name: adc_correction
+    enabled: true
+    description: "Apply Analog-to-Digital Conversion (ADC) nonlinearity correction."
+    params: ${calibration/step_definitions/adc_correction}
+
+  - name: dark_correction
+    enabled: true
+    description: "Subtract dark current from raw frames."
+    params: ${calibration/step_definitions/dark_correction}
+
+  - name: flat_field_correction
+    enabled: true
+    description: "Correct for pixel-to-pixel sensitivity variations."
+    params: ${calibration/step_definitions/flat_field_correction}
+
+  - name: cosmic_ray_removal
+    enabled: true
+    description: "Identify and remove cosmic ray hits in the detector frames."
+    params: ${calibration/step_definitions/cosmic_ray_removal}
+
+  - name: cds_computation
+    enabled: true
+    description: "Compute correlated double sampling (CDS) to reduce read noise."
+    params: ${calibration/step_definitions/cds_computation}
+
+  - name: trace_extraction
+    enabled: true
+    description: "Extract spectral or photometric traces from the corrected frames."
+    params: ${calibration/step_definitions/trace_extraction}
+
+  - name: wavelength_calibration
+    enabled: true
+    description: "Apply wavelength calibration to spectral traces."
+    params: ${calibration/step_definitions/wavelength_calibration}
+
+  - name: flux_calibration
+    enabled: true
+    description: "Convert counts to physical flux units."
+    params: ${calibration/step_definitions/flux_calibration}
+
+  - name: phase_alignment
+    enabled: true
+    description: "Align light curves in orbital phase for transit/eclipse analysis."
+    params: ${calibration/step_definitions/phase_alignment}
+
+  - name: final_qc
+    enabled: true
+    description: "Run quality control checks on calibrated products before modeling."
+    params: ${calibration/step_definitions/final_qc}

--- a/configs/calibration/steps/step_definitions/default.yaml
+++ b/configs/calibration/steps/step_definitions/default.yaml
@@ -1,0 +1,61 @@
+# Hydra configuration with default parameters for each calibration step.
+
+# @package _group_
+# Default parameter templates for each calibration step in SpectraMind V50.
+
+raw_ingest:
+  input_path: ${paths.raw_data}
+  output_path: ${paths.intermediate}/ingested
+  file_pattern: "*.fits"
+  verify_checksums: true
+
+adc_correction:
+  method: "polynomial"
+  poly_order: 3
+  reference_file: ${paths.calibration}/adc_coeffs.fits
+
+dark_correction:
+  method: "median_stack"
+  reference_file: ${paths.calibration}/dark_frame.fits
+  scale_by_exptime: true
+
+flat_field_correction:
+  method: "divide"
+  reference_file: ${paths.calibration}/flat_field.fits
+  normalize: true
+
+cosmic_ray_removal:
+  method: "lacosmic"
+  threshold_sigma: 5.0
+  neighbor_sigma: 2.0
+  max_iter: 4
+
+cds_computation:
+  method: "pair_subtraction"
+  use_rolling_pairs: false
+
+trace_extraction:
+  method: "optimal"
+  aperture_radius: 7.0
+  background_subtract: true
+  background_poly_order: 2
+
+wavelength_calibration:
+  reference_file: ${paths.calibration}/wavelength_solution.fits
+  method: "linear_interp"
+  apply_drift_correction: true
+
+flux_calibration:
+  reference_file: ${paths.calibration}/flux_standard.fits
+  method: "relative"
+  apply_extinction_correction: true
+
+phase_alignment:
+  ephemeris_file: ${paths.metadata}/ephemerides.csv
+  oversample_factor: 5
+  interpolation: "spline"
+
+final_qc:
+  run_symbolic_checks: true
+  generate_diagnostic_plots: true
+  save_summary_json: ${paths.logs}/calibration_qc_summary.json


### PR DESCRIPTION
## Summary
- add Hydra configs for default calibration pipeline steps
- provide parameter templates for each calibration step

## Testing
- `pre-commit run --files configs/calibration/steps/default.yaml configs/calibration/steps/step_definitions/default.yaml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689fe027a7f8832aa07445ec196745e3