### PR TITLE
Add parallel Hydra config tree with logging and help

### DIFF
--- a/conf/hydra/README.md
+++ b/conf/hydra/README.md
@@ -1,0 +1,11 @@
+# conf/hydra
+
+This directory mirrors `configs/hydra` to support parallel Hydra configuration resolution patterns used across different entrypoints and tooling. Keep both trees synchronized.
+
+- `config.yaml`: master Hydra anchors (run/sweep dirs, job meta, defaults).
+- `job_logging/default.yaml`: console + rotating file logs + JSONL event stream.
+- `launcher/basic.yaml`: local/basic launcher.
+- `sweeper/basic.yaml`: basic sweeper for param scans.
+- `help.yaml`: CLI help banner/footer for SpectraMind V50.
+
+> Recommendation: Add a CI check to diff `configs/hydra/**` vs `conf/hydra/**` to enforce synchronization.

--- a/conf/hydra/config.yaml
+++ b/conf/hydra/config.yaml
@@ -1,6 +1,7 @@
-# Master Hydra configuration for SpectraMind V50
+# conf/hydra/config.yaml
+# Master Hydra configuration for SpectraMind V50 (parallel tree to configs/hydra)
 # Registers logging, sweeper/launcher, and output directories.
-# This file anchors all sub-configs in configs/hydra.
+# This file anchors all sub-configs in conf/hydra.
 
 hydra:
   run:

--- a/conf/hydra/help.yaml
+++ b/conf/hydra/help.yaml
@@ -1,3 +1,4 @@
+# conf/hydra/help.yaml
 # Provides command-line help metadata for Hydra subcommands in SpectraMind V50.
 
 hydra:

--- a/conf/hydra/job_logging/default.yaml
+++ b/conf/hydra/job_logging/default.yaml
@@ -1,3 +1,4 @@
+# conf/hydra/job_logging/default.yaml
 # Default job logging config for SpectraMind V50.
 # Uses rotating file handlers, console output, and JSONL streams.
 
@@ -22,7 +23,7 @@ handlers:
     formatter: simple
     level: DEBUG
     filename: logs/v50_run.log
-    maxBytes: 5_000_000
+    maxBytes: 5000000
     backupCount: 5
 
   jsonl:

--- a/conf/hydra/launcher/basic.yaml
+++ b/conf/hydra/launcher/basic.yaml
@@ -1,6 +1,7 @@
+# conf/hydra/launcher/basic.yaml
 # Basic Hydra launcher for local execution.
 # Suitable for laptop / devcontainer runs.
-# Advanced launchers (e.g. submitit, slurm) can override this.
+# Advanced launchers (e.g., submitit, slurm) can override this.
 
 class: hydra._internal.core_plugins.basic_launcher.BasicLauncher
 params: {}

--- a/conf/hydra/sweeper/basic.yaml
+++ b/conf/hydra/sweeper/basic.yaml
@@ -1,4 +1,5 @@
-# Basic Hydra sweeper for param sweeps.
+# conf/hydra/sweeper/basic.yaml
+# Basic Hydra sweeper for parameter sweeps.
 # Allows grid and random sweeps across configs.
 
 class: hydra._internal.core_plugins.basic_sweeper.BasicSweeper


### PR DESCRIPTION
## Summary
- add parallel `conf/hydra` tree mirroring `configs/hydra`
- include rotating log handlers and JSONL output
- provide basic launcher, sweeper, and CLI help docs

## Testing
- `pre-commit run --files conf/hydra/config.yaml conf/hydra/help.yaml conf/hydra/job_logging/default.yaml conf/hydra/launcher/basic.yaml conf/hydra/sweeper/basic.yaml conf/hydra/README.md`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689feaaf6200832a9ae832ce7c8bbe58