### PR TITLE
chore: sync hydra configs and ignore doc file

### DIFF
--- a/conf/hydra/config.yaml
+++ b/conf/hydra/config.yaml
@@ -1,7 +1,6 @@
-# conf/hydra/config.yaml
-# Master Hydra configuration for SpectraMind V50 (parallel tree to configs/hydra)
+# Master Hydra configuration for SpectraMind V50
 # Registers logging, sweeper/launcher, and output directories.
-# This file anchors all sub-configs in conf/hydra.
+# This file anchors all sub-configs in configs/hydra.
 
 hydra:
   run:

--- a/conf/hydra/help.yaml
+++ b/conf/hydra/help.yaml
@@ -1,4 +1,3 @@
-# conf/hydra/help.yaml
 # Provides command-line help metadata for Hydra subcommands in SpectraMind V50.
 
 hydra:

--- a/conf/hydra/job_logging/default.yaml
+++ b/conf/hydra/job_logging/default.yaml
@@ -1,4 +1,3 @@
-# conf/hydra/job_logging/default.yaml
 # Default job logging config for SpectraMind V50.
 # Uses rotating file handlers, console output, and JSONL streams.
 
@@ -23,7 +22,7 @@ handlers:
     formatter: simple
     level: DEBUG
     filename: logs/v50_run.log
-    maxBytes: 5000000
+    maxBytes: 5_000_000
     backupCount: 5
 
   jsonl:

--- a/conf/hydra/launcher/basic.yaml
+++ b/conf/hydra/launcher/basic.yaml
@@ -1,7 +1,6 @@
-# conf/hydra/launcher/basic.yaml
 # Basic Hydra launcher for local execution.
 # Suitable for laptop / devcontainer runs.
-# Advanced launchers (e.g., submitit, slurm) can override this.
+# Advanced launchers (e.g. submitit, slurm) can override this.
 
 class: hydra._internal.core_plugins.basic_launcher.BasicLauncher
 params: {}

--- a/conf/hydra/sweeper/basic.yaml
+++ b/conf/hydra/sweeper/basic.yaml
@@ -1,5 +1,4 @@
-# conf/hydra/sweeper/basic.yaml
-# Basic Hydra sweeper for parameter sweeps.
+# Basic Hydra sweeper for param sweeps.
 # Allows grid and random sweeps across configs.
 
 class: hydra._internal.core_plugins.basic_sweeper.BasicSweeper

--- a/tools/check_hydra_sync.py
+++ b/tools/check_hydra_sync.py
@@ -61,8 +61,8 @@ SRC = os.path.normpath("configs/hydra")
 DST = os.path.normpath("conf/hydra")
 
 DEFAULT_IGNORES = [
-    # Add ignorable patterns here if needed:
-    # "README.md",
+    # Meta documentation not part of the mirrored tree
+    "README.md",
 ]
 
 


### PR DESCRIPTION
## Summary
- ignore README.md in hydra sync checker
- sync conf/hydra with configs/hydra

## Testing
- `pre-commit run --files tools/check_hydra_sync.py conf/hydra/config.yaml conf/hydra/help.yaml conf/hydra/job_logging/default.yaml conf/hydra/launcher/basic.yaml conf/hydra/sweeper/basic.yaml`
- `python tools/check_hydra_sync.py --verbose`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689fee448cc8832a950c26d2f7a422d2