### PR TITLE
Add Hydra launcher configuration profiles

### DIFF
--- a/configs/hydra/launcher/README.md
+++ b/configs/hydra/launcher/README.md
@@ -1,238 +1,117 @@
 # Hydra Launcher Group — SpectraMind V50
 
-This directory defines the **Hydra launcher group** for SpectraMind V50. Launchers control **how** and **where** jobs run (local, parallel, SLURM, Kaggle). Selecting a launcher never changes your experiment semantics — only the execution environment — and all runs remain **reproducible** with consistent logging and config snapshots.
-
----
+This directory defines the Hydra **launcher group** for SpectraMind V50. Launchers control how and where jobs run (local sequential, local parallel, SLURM, Kaggle). Selecting a launcher changes only the execution environment — not experiment semantics — and all runs remain reproducible with consistent logging and config snapshots.
 
 ## Files
 
-* `default.yaml` — entry point that chooses the active launcher (overridable at the CLI).
-* `basic.yaml` — default **local sequential** launcher (safe for debugging and CI).
-* `local.yaml` — **local parallel** multirun using Hydra’s basic launcher with `max_parallel_jobs`.
-* `slurm.yaml` — **HPC cluster** launcher targeting SLURM via Submitit.
-* `kaggle.yaml` — **Kaggle GPU** runtime profile with 9-hour guardrails and env tagging.
+* `default.yaml` — entry point that chooses the active launcher (override at CLI).
+* `basic.yaml` — local sequential launcher (safe for debugging/CI).
+* `local.yaml` — local parallel multirun using Hydra’s BasicLauncher with `max_parallel_jobs`.
+* `slurm.yaml` — HPC cluster launcher targeting SLURM via Submitit.
+* `kaggle.yaml` — Kaggle GPU runtime profile with 9-hour guardrails and env tagging.
 
-All launchers write:
+## Run output layout (same for all launchers)
 
-* Single runs → `logs/runs/YYYY-MM-DD/HH-MM-SS/`
-* Multiruns   → `logs/multiruns/YYYY-MM-DD/HH-MM-SS/`
-* Hydra state → `.hydra/` (config, overrides, and `hydra.yaml` snapshots)
+* Single runs  → `logs/runs/YYYY-MM-DD/HH-MM-SS/`
+* Multiruns    → `logs/multiruns/YYYY-MM-DD/HH-MM-SS/`
+* Hydra state  → `.hydra/` (merged config snapshot, `overrides.yaml`, `hydra.yaml`)
 
-These locations are controlled by `hydra.run.dir`, `hydra.sweep.dir`, and `hydra.output_subdir` in `default.yaml`.
-
----
-
-## Quick Start
-
-### Pick a launcher at runtime
+## Quick start
 
 * Sequential local:
-
-  ```
-  python -m spectramind.cli.spectramind train hydra/launcher=basic
-  ```
+  `python -m spectramind.cli.spectramind train hydra/launcher=basic`
 * Parallel local (e.g., 4 jobs):
-
+  `python -m spectramind.cli.spectramind ablate -m hydra/launcher=local hydra.launcher.max_parallel_jobs=4`
+* SLURM (one GPU, 32GB, 8 CPUs; override as needed):
   ```
-  python -m spectramind.cli.spectramind ablate hydra/launcher=local hydra.launcher.max_parallel_jobs=4
-  ```
-* SLURM (one GPU, 32GB, 8 CPUs; edit as needed or override at CLI):
-
-  ```
-  python -m spectramind.cli.spectramind train \
-    hydra/launcher=slurm \
-    hydra.launcher.partition=gpu \
-    hydra.launcher.gres=gpu:1 \
-    hydra.launcher.cpus_per_task=8 \
-    hydra.launcher.mem_gb=32 \
-    hydra.launcher.timeout_min=600
+  python -m spectramind.cli.spectramind train -m  
+  hydra/launcher=slurm  
+  hydra.launcher.partition=gpu  
+  hydra.launcher.gres=gpu:1  
+  hydra.launcher.cpus_per_task=8  
+  hydra.launcher.mem_gb=32  
+  hydra.launcher.timeout_min=600
   ```
 * Kaggle GPU runtime (sequential by platform constraints):
+  `python -m spectramind.cli.spectramind submit hydra/launcher=kaggle`
 
-  ```
-  python -m spectramind.cli.spectramind submit hydra/launcher=kaggle
-  ```
-
-> Tip: You can also change the default by editing `defaults` in `default.yaml`.
-
----
-
-## Common Patterns
-
-### 1) Multirun (sweeps) with parallel local launcher
-
-```
-python -m spectramind.cli.spectramind train \
-  -m hydra/launcher=local hydra.launcher.max_parallel_jobs=6 \
-  model.lr=1e-4,2e-4,5e-4 seed=7,11,13
-```
-
-Hydra creates one subfolder per combination under `logs/multiruns/.../` and saves a `.hydra/` state per job.
-
-### 2) SLURM array-style sweeps
-
-Submitit handles array-like multiruns transparently when you pass `-m`:
-
-```
-python -m spectramind.cli.spectramind train \
-  -m hydra/launcher=slurm \
-  hydra.launcher.partition=gpu \
-  hydra.launcher.gres=gpu:1 \
-  seed=0,1,2
-```
-
-Logs and `.hydra/` snapshots for each task are kept under the sweep directory; Submitit metadata is stored in `${hydra.sweep.dir}/.slurm_submitit`.
-
-### 3) Kaggle runtime guardrails
-
-Kaggle provides a single GPU with a hard wall-time. The `kaggle.yaml` profile:
-
-* sets `env.KAGGLE=true` and `env.KAGGLE_GPU=1` for programmatic checks,
-* recommends `timeout_min=540` (9 hours),
-* runs sequentially (no parallel sweeps).
-
-Example:
-
-```
-python -m spectramind.cli.spectramind submit \
-  hydra/launcher=kaggle \
-  pipeline.leaderboard_mode=true \
-  runtime.max_duration_min=520
-```
-
----
-
-## Reproducibility & Logging
-
+## Reproducibility & logging
 Each run records:
 
-* **Effective configs** in `.hydra/`:
+* `.hydra/config.yaml` (full merged config), `overrides.yaml`, `hydra.yaml`
+* Console + rotating file logs; optional JSONL event stream
+* ENV & Git metadata via SpectraMind runtime hooks
+* Optional MLflow/W&B sync if enabled
 
-  * `config.yaml` — full merged config for the run
-  * `overrides.yaml` — CLI overrides
-  * `hydra.yaml` — Hydra’s own resolved config
-* **Console logs** + **rotating file logs** (see project logging package)
-* **JSONL event stream** (if enabled by logging config)
-* **ENV & Git metadata** (captured by SpectraMind’s runtime hooks)
-* Optional MLflow/W&B sync (respects your config flags)
+Reproduce a past run by reusing `.hydra/config.yaml` or `.hydra/overrides.yaml` with the same environment (Poetry/Docker) and data/DVC state.
 
-Reproducing a run is as simple as:
+## Local parallelism
+`local.yaml` exposes `max_parallel_jobs`:
+`hydra/launcher=local hydra.launcher.max_parallel_jobs=8`
+Mind GPU contention; set per-run device affinity (e.g., `CUDA_VISIBLE_DEVICES`) if needed.
 
-1. `cd` into the run directory.
-2. Reuse the saved `overrides.yaml` or the full `config.yaml` with your CLI.
-3. Ensure the same environment (Python/Poetry/Docker) and data cache/DVC state.
+## SLURM (Submitit) notes
+Key fields in `slurm.yaml`:
 
----
+* `partition`, `gres`, `cpus_per_task`, `mem_gb`, `timeout_min`, `max_num_timeout`
+* `submitit_folder` for job metadata; `name` for SLURM job names
+  Useful overrides:
+  `hydra.launcher.nodelist=nodeA`
+  `hydra.launcher.qos=high`
+  `hydra.launcher.account=my_lab`
+  `hydra.launcher.array_parallelism=4`
+  Ensure `hydra-submitit-launcher` is installed.
 
-## SLURM Notes (Submitit)
+## Kaggle notes
 
-* **Key fields** in `slurm.yaml`:
+* Single GPU, sequential execution, strict wall-time
+* Avoid large `-m` sweeps; run curated configs
+* Keep artifacts under working directory; be mindful of disk limits
+* Use lightweight logs/HTML exports
 
-  * `partition`, `gres`, `cpus_per_task`, `mem_gb`, `timeout_min`, `max_num_timeout`
-  * `submitit_folder` to keep Submitit’s pickles and job descriptors
-  * `name` to tag SLURM job names
-* **Useful overrides**:
-
-  ```
-  hydra.launcher.nodelist=nodeA
-  hydra.launcher.qos=high
-  hydra.launcher.account=my_lab
-  hydra.launcher.array_parallelism=4
-  ```
-* Make sure `hydra-submitit-launcher` is installed in your environment.
-
----
-
-## Kaggle Notes
-
-* Single GPU, sequential execution, tight wall time.
-* Avoid large `-m` sweeps; instead, run curated configs.
-* Ensure all artifacts write to the working directory and that the submission bundle is kept under Kaggle’s output path.
-* Prefer lightweight logs and HTML exports to fit disk limits.
-
----
-
-## Local Parallelism
-
-`local.yaml` exposes `max_parallel_jobs`. Example:
-
-```
-hydra/launcher=local hydra.launcher.max_parallel_jobs=8
-```
-
-Use with care if your experiments require exclusive GPU access. Combine with per-run device affinity (e.g., `CUDA_VISIBLE_DEVICES`) if needed.
-
----
-
-## Changing the Default Launcher
-
+## Change the default launcher
 Edit `configs/hydra/launcher/default.yaml`:
-
 ```
 defaults:
-  - override hydra/launcher: basic   # change to local | slurm | kaggle
+- override hydra/launcher: basic
 ```
-
-Or override at the CLI: `hydra/launcher=slurm`.
-
----
+Or override at CLI: `hydra/launcher=slurm`
 
 ## Troubleshooting
 
-* **Jobs queued but not running (SLURM)**: Check `partition`, `account`, `qos`, and cluster policies. Reduce `mem_gb` or `cpus_per_task` if constrained.
-* **CUDA OOM**: Lower batch size or ensure jobs are serialized per GPU. On local parallel runs, set `max_parallel_jobs=1` for exclusive access.
-* **Permission denied writing logs**: Confirm `logs/` is writable. The default paths are relative to the CWD that launches the run.
-* **Hydra sweep too many runs**: Use smaller grids, random sampling (if enabled in your sweep logic), or increase `array_parallelism` on SLURM.
+* SLURM jobs idle: check partition/account/qos; reduce `mem_gb`/`cpus_per_task`
+* CUDA OOM: lower batch size; serialize jobs (`max_parallel_jobs=1`)
+* Log write issues: confirm `logs/` is writable; paths are relative to CWD
+* Too many sweep runs: shrink grids or use random sampling; control SLURM array parallelism
 
----
-
-## Minimal Examples
+## Minimal examples
 
 * Single run (default/basic):
-
-  ```
-  python -m spectramind.cli.spectramind train
-  ```
+  `python -m spectramind.cli.spectramind train`
 * Explicit basic:
-
+  `python -m spectramind.cli.spectramind train hydra/launcher=basic`
+* Local parallel dashboard (4 workers):
   ```
-  python -m spectramind.cli.spectramind train hydra/launcher=basic
-  ```
-* Local parallel (4 workers):
-
-  ```
-  python -m spectramind.cli.spectramind diagnose dashboard -m \
-    hydra/launcher=local hydra.launcher.max_parallel_jobs=4 \
-    diagnostics.umap=true diagnostics.tsne=true
+  python -m spectramind.cli.spectramind diagnose dashboard -m  
+  hydra/launcher=local hydra.launcher.max_parallel_jobs=4  
+  diagnostics.umap=true diagnostics.tsne=true
   ```
 * SLURM long job:
-
   ```
-  python -m spectramind.cli.spectramind ablate -m \
-    hydra/launcher=slurm \
-    hydra.launcher.partition=gpu \
-    hydra.launcher.gres=gpu:1 \
-    hydra.launcher.mem_gb=48 \
-    hydra.launcher.timeout_min=1200 \
-    ablate.top_n=20
+  python -m spectramind.cli.spectramind ablate -m  
+  hydra/launcher=slurm  
+  hydra.launcher.partition=gpu  
+  hydra.launcher.gres=gpu:1  
+  hydra.launcher.mem_gb=48  
+  hydra.launcher.timeout_min=1200  
+  ablate.top_n=20
   ```
 * Kaggle submission:
+  `python -m spectramind.cli.spectramind submit hydra/launcher=kaggle`
 
-  ```
-  python -m spectramind.cli.spectramind submit hydra/launcher=kaggle
-  ```
+## Best practices
 
----
-
-## Best Practices
-
-* Keep launcher-specific resource requests **in the config** and only override **at the CLI** when probing capacity.
-* Always check the saved `.hydra/` folder to reproduce exact runs.
-* For CI, prefer `basic.yaml` to reduce variability.
-* For large sweeps, use SLURM arrays via `-m` and control parallelism with cluster policy and launcher parameters.
-
----
-
-## Extending Launchers
-
-You can add more launchers (e.g., PBS, LSF, Ray) by adding a new YAML (e.g., `ray.yaml`) and pointing `_target_` to the corresponding Hydra plugin. Then select it via `hydra/launcher=ray` at the CLI.
+* Keep resource requests in config; override via CLI only when probing capacity
+* Always inspect `.hydra/` snapshots to reproduce exact runs
+* Prefer `basic.yaml` for CI to minimize variability
+* Use SLURM arrays for large sweeps and throttle with `array_parallelism`

--- a/configs/hydra/launcher/default.yaml
+++ b/configs/hydra/launcher/default.yaml
@@ -1,0 +1,20 @@
+# -----------------------------------------------------------------------------
+# Default Hydra launcher configuration for SpectraMind V50
+# -----------------------------------------------------------------------------
+# This file defines the active Hydra launcher via the "launcher" config group.
+# Usage:
+# hydra/launcher=basic    # local sequential (safe for debug/CI)
+# hydra/launcher=local    # local parallel multirun
+# hydra/launcher=slurm    # SLURM via Submitit
+# hydra/launcher=kaggle   # Kaggle GPU runtime constraints
+# -----------------------------------------------------------------------------
+
+defaults:
+  - override hydra/launcher: basic
+
+hydra:
+  run:
+    dir: logs/runs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: logs/multiruns/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  output_subdir: .hydra

--- a/configs/hydra/launcher/kaggle.yaml
+++ b/configs/hydra/launcher/kaggle.yaml
@@ -1,0 +1,19 @@
+# -----------------------------------------------------------------------------
+# Kaggle GPU runtime profile (local BasicLauncher with guardrails)
+# -----------------------------------------------------------------------------
+# Kaggle constraints:
+# - Single GPU runtime
+# - Hard 9-hour wall-time
+# - Sequential execution only (no large parallel sweeps)
+# This profile tags the environment and provides a timeout hint you can use
+# inside your pipeline to exit gracefully before wall-time.
+# -----------------------------------------------------------------------------
+_target_: hydra._internal.core_plugins.basic_launcher.BasicLauncher
+
+# Environment tags for programmatic checks in SpectraMind
+env:
+  KAGGLE: true
+  KAGGLE_GPU: 1
+
+# Soft timeout hint (the pipeline may choose to respect this)
+timeout_min: 540  # 9 hours

--- a/configs/hydra/launcher/local.yaml
+++ b/configs/hydra/launcher/local.yaml
@@ -1,0 +1,10 @@
+# -----------------------------------------------------------------------------
+# Local parallel launcher (Hydra BasicLauncher with concurrency)
+# -----------------------------------------------------------------------------
+# Launches multiple jobs in parallel on the local machine. Use with care if
+# experiments require exclusive GPU access. Pair with device pinning if needed.
+# -----------------------------------------------------------------------------
+_target_: hydra._internal.core_plugins.basic_launcher.BasicLauncher
+
+# Number of concurrent jobs Hydra will launch locally
+max_parallel_jobs: 4

--- a/configs/hydra/launcher/slurm.yaml
+++ b/configs/hydra/launcher/slurm.yaml
@@ -1,0 +1,25 @@
+# -----------------------------------------------------------------------------
+# SLURM cluster launcher using hydra-submitit-launcher
+# -----------------------------------------------------------------------------
+# Submit parallel/multi-run jobs to a SLURM cluster with GPU resources.
+# You can override any field at the CLI (see README.md for examples).
+# -----------------------------------------------------------------------------
+_target_: hydra_plugins.hydra_submitit_launcher.submitit_launcher.SlurmLauncher
+
+# Core resources (override as needed)
+partition: gpu
+gres: gpu:1
+cpus_per_task: 8
+mem_gb: 32
+timeout_min: 600        # 10 hours
+max_num_timeout: 1
+
+# Optional extras (uncomment/override at CLI as needed)
+# qos: high
+# account: your_account
+# nodelist: nodeA
+# array_parallelism: 4
+
+# Submitit/Hydra metadata
+submitit_folder: ${hydra.sweep.dir}/.slurm_submitit
+name: spectramind_v50


### PR DESCRIPTION
## Summary
- add Hydra launcher config group files for basic, local, slurm, and kaggle profiles
- document available launchers and usage in updated README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_689ff5704f5c832ab7196d01fc39f7d0