### PR TITLE
feat: add Optuna sweeper configuration

### DIFF
--- a/configs/hydra/config.yaml
+++ b/configs/hydra/config.yaml
@@ -22,8 +22,8 @@ hydra:
         item_sep: ','
         exclude_keys: [seed]
 
-  # Include defaults for job_logging and launcher
+  # Include defaults for job_logging, launcher, and sweeper
   defaults:
     - hydra/job_logging: default
     - hydra/launcher: basic
-    - hydra/sweeper: basic
+    - hydra/sweeper: optuna

--- a/configs/hydra/sweeper/README.md
+++ b/configs/hydra/sweeper/README.md
@@ -1,0 +1,35 @@
+# Hydra Sweeper Configs
+
+This directory defines hyperparameter search strategies for **SpectraMind V50**.
+
+## Files
+- **optuna.yaml** — Optuna-based hyperparameter sweeper (default).
+  - Uses TPE sampler with deterministic seed.
+  - Supports `training.lr`, `batch_size`, `encoder_dim`, `dropout`, and `weight_decay`.
+  - Objective: minimize Generalized Log Likelihood (GLL).
+- **basic.yaml** — Minimal Hydra sweeper (grid/random) for debugging.
+
+## Usage
+
+### Run Optuna sweep (default)
+```bash
+python train_v50.py -m
+```
+
+### Override sweeper
+
+```bash
+python train_v50.py -m hydra/sweeper=basic
+```
+
+### Override search space at CLI
+
+```bash
+python train_v50.py -m training.lr=tag(log,interval(1e-4,1e-2)) model.dropout=interval(0.1,0.3)
+```
+
+## Notes
+
+* All sweeps log metadata (commit hash, ENV, config hash) for reproducibility.
+* Parallelism (`n_jobs`) integrates with Hydra launcher configs (see `configs/hydra/launcher`).
+* For large sweeps, configure persistent Optuna storage (e.g., SQLite or PostgreSQL).

--- a/configs/hydra/sweeper/basic.yaml
+++ b/configs/hydra/sweeper/basic.yaml
@@ -1,7 +1,10 @@
-# Basic Hydra sweeper for param sweeps.
-# Allows grid and random sweeps across configs.
+# Simple grid/random sweeper configuration
+# Useful for debugging sweeps without Optuna overhead.
 
-class: hydra._internal.core_plugins.basic_sweeper.BasicSweeper
-params:
-  # Maximum number of runs in a sweep
-  max_batch_size: 16
+defaults:
+  - override /hydra/sweeper: basic
+
+hydra:
+  sweeper:
+    _target_: hydra._internal.core_plugins.basic_sweeper.BasicSweeper
+    max_batch_size: null

--- a/configs/hydra/sweeper/optuna.yaml
+++ b/configs/hydra/sweeper/optuna.yaml
@@ -1,0 +1,26 @@
+# Hydra sweeper config using Optuna
+# This config controls hyperparameter search for SpectraMind V50
+# Reproducibility: all seeds and logs are tied to Git commit hash and ENV capture.
+
+defaults:
+  - override /hydra/sweeper: optuna
+
+hydra:
+  sweeper:
+    _target_: hydra_plugins.hydra_optuna_sweeper.optuna_sweeper.OptunaSweeper
+    sampler:
+      _target_: optuna.samplers.TPESampler
+      seed: 42                # Deterministic sweeps
+      multivariate: true
+      group: true
+    direction: minimize        # GLL loss minimization objective
+    study_name: spectramind_v50_sweep
+    storage: null              # Use in-memory by default; can set RDB for multi-node runs
+    n_trials: 50               # Default number of trials; override on CLI with +n_trials=N
+    n_jobs: 1                  # Parallelism per node; integrate with launcher for multi-GPU
+    params:
+      training.lr: tag(log, interval(1e-5, 1e-2))
+      training.batch_size: choice(16, 32, 64)
+      model.encoder_dim: choice(256, 512, 768)
+      model.dropout: interval(0.0, 0.5)
+      optimizer.weight_decay: interval(1e-6, 1e-3)


### PR DESCRIPTION
## Summary
- add Optuna sweeper config for hyperparameter searches
- document sweeper usage and defaults
- default Hydra to Optuna sweeper and refresh basic sweeper config

## Testing
- `pre-commit run --files configs/hydra/sweeper/optuna.yaml configs/hydra/sweeper/basic.yaml configs/hydra/sweeper/README.md configs/hydra/config.yaml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689ff68e2eb8832aaaf470ab270c7d7a