### PR TITLE
feat: centralize path settings via Hydra configs

### DIFF
--- a/configs/config_v50.yaml
+++ b/configs/config_v50.yaml
@@ -1,6 +1,6 @@
 # Root Hydra configuration for SpectraMind V50.
 
-# Compose with: model/defaults, training/default, data/ariel, logging/default, paths/default
+# Compose with: model/defaults, training/default, data/ariel, logging/default, paths/config
 
 # This file is the single entry-point for CLI tools: --config-name config_v50
 
@@ -9,7 +9,7 @@ defaults:
   - training: default
   - data: ariel
   - logging: default
-  - paths: default
+  - paths: config
   - hydra/job_logging: rich
   - hydra/hydra_logging: rich
 
@@ -21,7 +21,7 @@ extras:
 # Optional global overrides (rarely used; prefer group files)
 hydra:
   run:
-    dir: ${paths.runs_dir}/${now:%Y-%m-%d}/${now:%H-%M-%S}${oc.env:USER,unknown}${hydra.job.name}_${hydra.job.num}
+    dir: ${paths.outputs.runs_dir}/${now:%Y-%m-%d}/${now:%H-%M-%S}${oc.env:USER,unknown}${hydra.job.name}_${hydra.job.num}
   sweep:
-    dir: ${paths.runs_dir}/multirun/${now:%Y-%m-%d}_${now:%H-%M-%S}
+    dir: ${paths.outputs.runs_dir}/multirun/${now:%Y-%m-%d}_${now:%H-%M-%S}
     subdir: ${hydra.job.num}_${hydra.runtime.choices}

--- a/configs/paths/README.md
+++ b/configs/paths/README.md
@@ -1,0 +1,25 @@
+# configs/paths
+
+This directory defines **all path-related Hydra configs** for SpectraMind V50.
+
+## Overview
+- **data.yaml** — raw, processed, cache, and external data dirs
+- **outputs.yaml** — checkpoints, predictions, artifacts
+- **logs.yaml** — console logs, JSONL streams, debug Markdown, run hash summaries
+- **submissions.yaml** — Kaggle submissions, validation runs, ZIP bundles
+- **dashboards.yaml** — HTML/JSON diagnostics dashboards, figures, reports
+- **config.yaml** — Hydra defaults glue, imports all above
+
+## Key Features
+- All paths parameterized with `${oc.env:VAR, default}` for reproducibility
+- Compatible with DVC/lakeFS for data versioning
+- Integrated with CI/CD + diagnostics dashboard
+- Ensures **reproducibility** (no hardcoded paths)
+
+## Usage
+```bash
+# Example: run training with custom data root
+python train_v50.py paths.data.raw_dir=/mnt/new_data/raw
+```
+
+This centralization ensures **NASA-grade reproducibility** and easy relocation across servers or Kaggle runtimes.

--- a/configs/paths/config.yaml
+++ b/configs/paths/config.yaml
@@ -1,0 +1,21 @@
+# configs/paths/config.yaml
+# Root paths config — imported by Hydra
+# Centralizes all project directory references for reproducibility
+
+defaults:
+  - data: data
+  - outputs: outputs
+  - logs: logs
+  - submissions: submissions
+  - dashboards: dashboards
+
+# Base project root
+project_root: ${oc.env:PROJECT_ROOT, .}
+
+# Backwards-compatibility aliases
+root: ${project_root}
+runs_dir: ${outputs.runs_dir}
+logs_dir: ${logs.logs_root}
+artifacts_dir: ${outputs.artifacts_dir}
+reports_dir: ${dashboards.dashboard_root}
+checkpoints_dir: ${outputs.checkpoints_dir}

--- a/configs/paths/dashboards.yaml
+++ b/configs/paths/dashboards.yaml
@@ -1,0 +1,10 @@
+# configs/paths/dashboards.yaml
+# Diagnostics dashboards and reports
+
+dashboard_root: ${oc.env:DASHBOARD_ROOT, ./dashboards}
+html_reports: ${paths.dashboards.dashboard_root}/html
+json_summaries: ${paths.dashboards.dashboard_root}/json
+figures: ${paths.dashboards.dashboard_root}/figures
+
+# Versioned outputs for reproducibility
+versioned_html: ${paths.dashboards.html_reports}/diagnostic_report_v${oc.env:REPORT_VERSION,1}.html

--- a/configs/paths/data.yaml
+++ b/configs/paths/data.yaml
@@ -1,0 +1,14 @@
+# configs/paths/data.yaml
+# Centralized data paths for the SpectraMind V50 pipeline
+
+raw_dir: ${oc.env:DATA_ROOT, /mnt/data}/raw
+processed_dir: ${oc.env:DATA_ROOT, /mnt/data}/processed
+cache_dir: ${oc.env:DATA_ROOT, /mnt/data}/cache
+external_dir: ${oc.env:DATA_ROOT, /mnt/data}/external
+
+# Challenge dataset references
+airs_frames: ${paths.data.raw_dir}/airs
+fgs1_frames: ${paths.data.raw_dir}/fgs1
+
+# DVC or lakeFS integration
+dvc_remote: ${oc.env:DVC_REMOTE, /mnt/dvc_remote}

--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -1,8 +1,0 @@
-# Paths group: default
-
-project_root: .
-runs_dir: runs
-logs_dir: logs
-artifacts_dir: artifacts
-reports_dir: reports
-checkpoints_dir: checkpoints

--- a/configs/paths/logs.yaml
+++ b/configs/paths/logs.yaml
@@ -1,0 +1,8 @@
+# configs/paths/logs.yaml
+# Logging, reproducibility, and monitoring directories
+
+logs_root: ${oc.env:LOG_ROOT, ./logs}
+console_log: ${paths.logs.logs_root}/console.log
+jsonl_stream: ${paths.logs.logs_root}/events.jsonl
+debug_md: ${paths.logs.logs_root}/v50_debug_log.md
+hash_summary: ${paths.logs.logs_root}/run_hash_summary_v50.json

--- a/configs/paths/outputs.yaml
+++ b/configs/paths/outputs.yaml
@@ -1,0 +1,10 @@
+# configs/paths/outputs.yaml
+# Model outputs, checkpoints, and experiment runs
+
+checkpoints_dir: ${oc.env:OUTPUT_ROOT, ./outputs}/checkpoints
+runs_dir: ${oc.env:OUTPUT_ROOT, ./outputs}/runs
+predictions_dir: ${oc.env:OUTPUT_ROOT, ./outputs}/predictions
+artifacts_dir: ${oc.env:OUTPUT_ROOT, ./outputs}/artifacts
+
+# Temporary staging for Kaggle submissions
+staging_dir: ${paths.outputs.artifacts_dir}/staging

--- a/configs/paths/submissions.yaml
+++ b/configs/paths/submissions.yaml
@@ -1,0 +1,7 @@
+# configs/paths/submissions.yaml
+# Paths for Kaggle leaderboard submissions and validation
+
+submission_dir: ${oc.env:SUBMISSION_ROOT, ./submissions}
+validations_dir: ${paths.submissions.submission_dir}/validations
+bundles_dir: ${paths.submissions.submission_dir}/bundles
+latest_zip: ${paths.submissions.bundles_dir}/latest_submission.zip

--- a/src/spectramind/config/base_config.py
+++ b/src/spectramind/config/base_config.py
@@ -6,9 +6,9 @@ SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field, asdict
-from typing import Dict, Any, List, Optional, Mapping, MutableMapping
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional
 
 
 @dataclass
@@ -17,20 +17,23 @@ class ModelConfig:
     Core model architecture configuration (neuro-symbolic + physics-aware).
     Fields map 1:1 with Hydra group: model/defaults.yaml.
     """
-    fgs1_encoder: str = "MambaSSM"                     # Long-seq state-space model for FGS1
-    airs_encoder: str = "GATConv"                      # Edge-aware spectral GNN for AIRS
-    decoder_mu: str = "MultiScaleDecoder"              # μ-spectrum multi-resolution head
-    decoder_sigma: str = "FlowUncertaintyHead"         # σ head with attention fusion
+
+    fgs1_encoder: str = "MambaSSM"  # Long-seq state-space model for FGS1
+    airs_encoder: str = "GATConv"  # Edge-aware spectral GNN for AIRS
+    decoder_mu: str = "MultiScaleDecoder"  # μ-spectrum multi-resolution head
+    decoder_sigma: str = "FlowUncertaintyHead"  # σ head with attention fusion
     latent_dim: int = 512
     # Symbolic constraint weights; each should be in [0, 10] and can be schedule-aware.
-    symbolic_loss_weights: Dict[str, float] = field(default_factory=lambda: {
-        "smoothness": 0.25,
-        "nonnegativity": 0.10,
-        "molecular_coherence": 0.15,
-        "asymmetry": 0.05,
-        "photonic_alignment": 0.10,
-        "fft_spectral": 0.10,
-    })
+    symbolic_loss_weights: Dict[str, float] = field(
+        default_factory=lambda: {
+            "smoothness": 0.25,
+            "nonnegativity": 0.10,
+            "molecular_coherence": 0.15,
+            "asymmetry": 0.05,
+            "photonic_alignment": 0.10,
+            "fft_spectral": 0.10,
+        }
+    )
     # Optional toggles/heads
     use_quantile_decoder: bool = False
     use_diffusion_decoder: bool = False
@@ -38,8 +41,10 @@ class ModelConfig:
     conformal_corel: bool = True
     corel_coverage: float = 0.90
     # Edge features for AIRS spectral graph
-    airs_edge_features: List[str] = field(default_factory=lambda: ["d_lambda", "molecule", "region"])
-    airs_posenc: str = "fourier"                       # {"none","sinusoidal","fourier"}
+    airs_edge_features: List[str] = field(
+        default_factory=lambda: ["d_lambda", "molecule", "region"]
+    )
+    airs_posenc: str = "fourier"  # {"none","sinusoidal","fourier"}
 
 
 @dataclass
@@ -47,16 +52,17 @@ class TrainingConfig:
     """
     Training hyperparameters & pipeline settings (Hydra group: training/default.yaml).
     """
+
     seed: int = 42
-    device: str = "cuda"                               # {"cuda","cpu"}
-    precision: str = "amp"                             # {"fp32","bf16","amp"}
+    device: str = "cuda"  # {"cuda","cpu"}
+    precision: str = "amp"  # {"fp32","bf16","amp"}
     batch_size: int = 32
     grad_accum: int = 1
     learning_rate: float = 3e-4
     weight_decay: float = 0.05
     epochs: int = 150
     warmup_epochs: int = 5
-    scheduler: str = "cosine"                          # {"cosine","none","onecycle"}
+    scheduler: str = "cosine"  # {"cosine","none","onecycle"}
     checkpoint_interval: int = 5
     resume_from: Optional[str] = None
     # Logging & tracking
@@ -79,6 +85,7 @@ class DataConfig:
     """
     Data settings & preprocessing (Hydra group: data/ariel.yaml).
     """
+
     # Canonical dataset layout; DVC/lakeFS may materialize here.
     root: Path = Path("data")
     train_split: str = "train"
@@ -87,11 +94,13 @@ class DataConfig:
     # Normalization/augmentation
     normalize: bool = True
     standardize: bool = False
-    augmentations: Dict[str, Any] = field(default_factory=lambda: {
-        "fgs1_jitter_injection": True,
-        "temporal_dropout": 0.05,
-        "airs_noise_sigma": 0.002,
-    })
+    augmentations: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "fgs1_jitter_injection": True,
+            "temporal_dropout": 0.05,
+            "airs_noise_sigma": 0.002,
+        }
+    )
     # Masking/calibration knobs
     snr_threshold: float = 0.0
     apply_calibration_pipeline: bool = True
@@ -102,8 +111,9 @@ class DataConfig:
 @dataclass
 class PathsConfig:
     """
-    Paths & artifacts (Hydra group: paths/default.yaml).
+    Paths & artifacts (Hydra group: paths/config.yaml).
     """
+
     project_root: Path = Path(".")
     runs_dir: Path = Path("runs")
     logs_dir: Path = Path("logs")
@@ -117,10 +127,11 @@ class LoggingConfig:
     """
     Logging preferences (Hydra group: logging/default.yaml).
     """
-    level: str = "INFO"                                # {"DEBUG","INFO","WARNING","ERROR"}
+
+    level: str = "INFO"  # {"DEBUG","INFO","WARNING","ERROR"}
     jsonl_path: Optional[Path] = Path("logs/events.jsonl")
     rotating_log_path: Optional[Path] = Path("logs/spectramind.log")
-    rotating_bytes: int = 10 * 1024 * 1024             # 10MB
+    rotating_bytes: int = 10 * 1024 * 1024  # 10MB
     rotating_backups: int = 5
     console_rich: bool = True
     color: bool = True
@@ -131,6 +142,7 @@ class Config:
     """
     Unified root configuration; mirrors configs/config_v50.yaml and composed groups.
     """
+
     model: ModelConfig = field(default_factory=ModelConfig)
     training: TrainingConfig = field(default_factory=TrainingConfig)
     data: DataConfig = field(default_factory=DataConfig)
@@ -149,6 +161,7 @@ class Config:
         Construct Config from Mapping (e.g., OmegaConf.to_container result).
         Unknown keys under known groups are passed through via extras.
         """
+
         def sub(name: str, typ):
             blob = dict(m.get(name, {}))
             # Separate out unknowns to extras
@@ -164,14 +177,23 @@ class Config:
         paths, paths_extra = sub("paths", PathsConfig)
         logging, logging_extra = sub("logging", LoggingConfig)
         extras = dict(m.get("extras", {}))
-        extras.update({
-            "model_extra": model_extra,
-            "training_extra": training_extra,
-            "data_extra": data_extra,
-            "paths_extra": paths_extra,
-            "logging_extra": logging_extra,
-        })
-        return cls(model=model, training=training, data=data, paths=paths, logging=logging, extras=extras)
+        extras.update(
+            {
+                "model_extra": model_extra,
+                "training_extra": training_extra,
+                "data_extra": data_extra,
+                "paths_extra": paths_extra,
+                "logging_extra": logging_extra,
+            }
+        )
+        return cls(
+            model=model,
+            training=training,
+            data=data,
+            paths=paths,
+            logging=logging,
+            extras=extras,
+        )
 
     def merge(self, patch: MutableMapping[str, Any]) -> "Config":
         """


### PR DESCRIPTION
## Summary
- add Hydra-driven `configs/paths` group to centralize data, output, log, submission, and dashboard directories
- wire root config to new paths group and clarify `PathsConfig` docstring

## Testing
- `pre-commit run --files configs/config_v50.yaml src/spectramind/config/base_config.py configs/paths/config.yaml configs/paths/data.yaml configs/paths/outputs.yaml configs/paths/logs.yaml configs/paths/submissions.yaml configs/paths/dashboards.yaml configs/paths/README.md`
- `pytest` *(fails: test_photonic_alignment, test_asymmetry)*

------
https://chatgpt.com/codex/tasks/task_e_689ffd57f6cc832aa584ff5b10edc949