### PR TITLE
Add domain diagnostic profiles and wire into Hydra defaults

### DIFF
--- a/configs/config_v50.yaml
+++ b/configs/config_v50.yaml
@@ -10,6 +10,7 @@ defaults:
   - data: ariel
   - logging: default
   - paths: config
+  - profiles: default
   - hydra/job_logging: rich
   - hydra/hydra_logging: rich
 

--- a/configs/defaults.yaml
+++ b/configs/defaults.yaml
@@ -6,3 +6,4 @@ defaults:
   - calibration: base
   - diagnostics: defaults
   - symbolic: base
+  - profiles: default

--- a/configs/profiles/README.md
+++ b/configs/profiles/README.md
@@ -1,0 +1,35 @@
+# configs/profiles
+
+This directory defines **symbolic and diagnostic profiles** for SpectraMind V50 using Hydra’s configuration grouping.
+
+## Purpose
+Profiles provide domain-specific configurations for symbolic rules, diagnostics, and reproducibility. They enable modular switching between astrophysics, chemistry, biology, cross-disciplinary, and GUI-focused modes.
+
+## Available Profiles
+- **default.yaml** – Baseline symbolic and diagnostic settings.
+- **astrophysics.yaml** – Physics-informed rules (FFT smoothness, photonic alignment, cosmology overlays).
+- **chemistry.yaml** – Quantum chemistry and molecular line constraints.
+- **biology.yaml** – Symbolic entropy and pathway consistency checks for biological systems.
+- **cross_disciplinary.yaml** – Fusion across AI, physics, chemistry, biology.
+- **gui.yaml** – Diagnostic/visualization overlays for dashboards.
+
+## Usage
+To activate a profile in Hydra CLI:
+```bash
+python train_v50.py profiles=astrophysics
+python diagnose_v50.py profiles=gui
+```
+
+## References
+
+Profiles are informed by:
+
+* Documentation-first protocol
+* Patterns, algorithms, fractals reference
+* NASA-grade scientific modeling
+* Physics & astrophysics modeling
+* Chemistry & biology foundations
+* Engineering guide to GUI systems
+* Foundational templates & glossary
+* Domain module examples
+* Ariel mission science context

--- a/configs/profiles/active.yaml
+++ b/configs/profiles/active.yaml
@@ -1,1 +1,0 @@
-../symbolic/overrides/profiles/local-dev.yaml

--- a/configs/profiles/astrophysics.yaml
+++ b/configs/profiles/astrophysics.yaml
@@ -1,0 +1,23 @@
+# Astrophysics-focused profile
+# Hydra group: profiles=astrophysics
+
+defaults:
+  - override hydra/job_logging: default
+
+profile:
+  name: astrophysics
+  description: |
+    Profile tuned for astrophysics and exoplanet spectroscopy.
+    Integrates physical constraints from Newtonian mechanics,
+    thermodynamics, spectroscopy, and relativity:contentReference[oaicite:9]{index=9}.
+  symbolic:
+    enable: true
+    rules: ["fft_smoothness", "asymmetry", "photonic_alignment", "energy_conservation"]
+    weighting: "physics_prioritized"
+  diagnostics:
+    enable_fft: true
+    molecular_templates: ["H2O", "CH4", "CO2"]
+    enable_cosmology_context: true
+  reproducibility:
+    seed: 2029
+    deterministic: true

--- a/configs/profiles/biology.yaml
+++ b/configs/profiles/biology.yaml
@@ -1,0 +1,19 @@
+# Biology-focused profile
+# Hydra group: profiles=biology
+
+profile:
+  name: biology
+  description: |
+    Profile for life sciences, cell/molecular biology,
+    and biochemistry overlays:contentReference[oaicite:11]{index=11}.
+    Includes entropy-based symbolic constraints for living systems.
+  symbolic:
+    enable: true
+    rules: ["entropy_minimization", "bio_pathway_consistency", "smoothness"]
+    weighting: "bio_centric"
+  diagnostics:
+    enable_umap: true
+    overlays: ["genetics", "metabolism", "ecology"]
+  reproducibility:
+    seed: 1982
+    deterministic: false

--- a/configs/profiles/chemistry.yaml
+++ b/configs/profiles/chemistry.yaml
@@ -1,0 +1,19 @@
+# Chemistry-focused profile
+# Hydra group: profiles=chemistry
+
+profile:
+  name: chemistry
+  description: |
+    Chemistry and spectroscopy oriented symbolic profile.
+    Incorporates quantum chemistry, bonding rules, and
+    molecule-region diagnostics:contentReference[oaicite:10]{index=10}.
+  symbolic:
+    enable: true
+    rules: ["stoichiometry_balance", "spectral_line_consistency", "nonnegativity"]
+    weighting: "molecular_priority"
+  diagnostics:
+    enable_shap: true
+    molecular_focus: ["H2O", "CO2", "O3", "NH3"]
+  reproducibility:
+    seed: 1977
+    deterministic: true

--- a/configs/profiles/cross_disciplinary.yaml
+++ b/configs/profiles/cross_disciplinary.yaml
@@ -1,0 +1,19 @@
+# Cross-disciplinary fusion profile
+# Hydra group: profiles=cross_disciplinary
+
+profile:
+  name: cross_disciplinary
+  description: |
+    Fusion profile integrating AI, physics, chemistry,
+    and biology rules into one symbolic logic ensemble:contentReference[oaicite:12]{index=12}:contentReference[oaicite:13]{index=13}:contentReference[oaicite:14]{index=14}.
+  symbolic:
+    enable: true
+    rules: ["smoothness", "fft_smoothness", "stoichiometry_balance", "bio_pathway_consistency"]
+    weighting: "balanced"
+  diagnostics:
+    enable_umap: true
+    enable_tsne: true
+    fusion_overlays: ["symbolic", "shap", "entropy"]
+  reproducibility:
+    seed: 2025
+    deterministic: true

--- a/configs/profiles/default.yaml
+++ b/configs/profiles/default.yaml
@@ -1,0 +1,26 @@
+# Default symbolic/diagnostic profile for SpectraMind V50
+# This profile acts as a baseline across all domains.
+# Hydra group: profiles=default
+
+defaults:
+  - override hydra/job_logging: default
+  - override hydra/launcher: basic
+  - override hydra/sweeper: basic
+
+profile:
+  name: default
+  description: |
+    Default SpectraMind V50 symbolic profile.
+    Uses general symbolic rules, FFT smoothness, entropy checks,
+    and calibration diagnostics.
+  symbolic:
+    enable: true
+    rules: ["smoothness", "nonnegativity", "entropy"]
+    weighting: "uniform"
+  diagnostics:
+    enable_fft: true
+    enable_shap: true
+    enable_symbolic_overlay: true
+  reproducibility:
+    seed: 42
+    deterministic: true

--- a/configs/profiles/gui.yaml
+++ b/configs/profiles/gui.yaml
@@ -1,0 +1,20 @@
+# GUI-focused profile
+# Hydra group: profiles=gui
+
+profile:
+  name: gui
+  description: |
+    Profile for GUI and dashboard integration:contentReference[oaicite:15]{index=15}.
+    Prioritizes symbolic overlays suitable for visualization in
+    interactive diagnostic dashboards.
+  symbolic:
+    enable: true
+    rules: ["entropy", "visual_smoothness", "attention_overlay"]
+    weighting: "visual_priority"
+  diagnostics:
+    enable_dashboard: true
+    enable_interactive_html: true
+    embed_overlays: ["umap", "tsne", "shap"]
+  reproducibility:
+    seed: 101
+    deterministic: true


### PR DESCRIPTION
## Summary
- add domain-aware Hydra profiles for default, astrophysics, chemistry, biology, cross_disciplinary, and gui modes
- document profile usage and register the profiles in master defaults
- enable `profiles=...` selection from top-level Hydra configs

## Testing
- `pre-commit run --files configs/config_v50.yaml configs/defaults.yaml configs/profiles/README.md configs/profiles/astrophysics.yaml configs/profiles/biology.yaml configs/profiles/chemistry.yaml configs/profiles/cross_disciplinary.yaml configs/profiles/default.yaml configs/profiles/gui.yaml`
- `pytest` *(fails: PhotonicAlignmentRule IndexError; AsymmetryRule IndexError)*

------
https://chatgpt.com/codex/tasks/task_e_68a000e77b5c832a8dd13b618f67ff8e