### PR TITLE
Wire profiles across configs and add profile helper

### DIFF
--- a/configs/calibration/steps/default.yaml
+++ b/configs/calibration/steps/default.yaml
@@ -66,3 +66,8 @@ steps:
     enabled: true
     description: "Run quality control checks on calibrated products before modeling."
     params: ${calibration/step_definitions/final_qc}
+
+  - name: molecular_region_qc
+    enabled: ${oc.select:diagnostics.molecular_focus,[]}
+    params:
+      focus_molecules: ${oc.select:diagnostics.molecular_focus,[]}

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,44 +1,32 @@
 # Master root config for SpectraMind V50 (Hydra)
-#
-# This file “registers” config groups and sets the default profile so users can
-# switch with `profiles=<name>` without specifying full paths.
-#
-# Example:
-# python -m spectramind.cli.spectramind train profiles=astrophysics
-# python -m spectramind.cli.spectramind diagnose dashboard profiles=gui
+# Registers the `profiles` group and makes its fields available globally.
 
 defaults:
-  # ── Core Hydra plumbing (adjust to your existing hydra/* files as needed)
   - hydra/job_logging: default
   - hydra/launcher: basic
   - hydra/sweeper: basic
 
-  # ── Profiles group: make the profile group active and choose a default
+  # Profiles group: choose the default profile; users can override with profiles=<name>
   - profiles: default
 
-  # ── (Optional) Add other project groups here so they’re discoverable too.
-  # - paths: default
-  # - diagnostics: default
-  # - calibration/steps: default
-  # - logging: default
-  # - model: default
+  # Project groups wired to read from the active profile (see their defaults files)
+  - logging: default
+  - diagnostics: default
+  - calibration/steps: default
+  - model: default
 
-# Global toggles that many subconfigs read (safe to keep minimal here).
 project:
   name: SpectraMind V50
-  mode: standard
+  mode: standard  # e.g., standard | leaderboard | ci
+
+# Expose the active profile universally
+active_profile: ${profiles.profile.name}
 
 reproducibility:
-  seed: 42
-  deterministic: true
+  seed: ${oc.select:profiles.profile.reproducibility.seed,42}
+  deterministic: ${oc.select:profiles.profile.reproducibility.deterministic,true}
 
-logging:
-  level: INFO
-  jsonl_events: true
-  file_rotation_mb: 25
-  file_keep: 5
-
-# Respect the active profile’s symbolic/diagnostics knobs by default.
+# Surface symbolic & diagnostics via profile (downstream groups refine this)
 symbolic:
   enable: ${profiles.profile.symbolic.enable}
   rules: ${profiles.profile.symbolic.rules}
@@ -56,7 +44,8 @@ diagnostics:
   molecular_focus: ${oc.select:profiles.profile.diagnostics.molecular_focus,[]}
   enable_cosmology_context: ${oc.select:profiles.profile.diagnostics.enable_cosmology_context,false}
 
-# Allow CLI tools to read the active profile name for logs/manifest.
-active_profile: ${profiles.profile.name}
-
-# End of file
+logging:
+  level: INFO
+  jsonl_events: true
+  file_rotation_mb: 25
+  file_keep: 5

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,0 +1,5 @@
+# Convenience entry so `-c configs` works even if someone resolves to "default"
+# and you still land on the full root in config.yaml.
+
+defaults:
+  - config

--- a/configs/diagnostics/default.yaml
+++ b/configs/diagnostics/default.yaml
@@ -1,0 +1,13 @@
+# Diagnostics group reads through from the selected profile but remains overrideable.
+
+diagnostics:
+  enable_fft: ${oc.select:diagnostics.enable_fft,false}
+  enable_shap: ${oc.select:diagnostics.enable_shap,false}
+  enable_symbolic_overlay: ${oc.select:diagnostics.enable_symbolic_overlay,false}
+  enable_dashboard: ${oc.select:diagnostics.enable_dashboard,false}
+  enable_interactive_html: ${oc.select:diagnostics.enable_interactive_html,false}
+  overlays: ${oc.select:diagnostics.overlays,[]}
+  fusion_overlays: ${oc.select:diagnostics.fusion_overlays,[]}
+  molecular_templates: ${oc.select:diagnostics.molecular_templates,[]}
+  molecular_focus: ${oc.select:diagnostics.molecular_focus,[]}
+  enable_cosmology_context: ${oc.select:diagnostics.enable_cosmology_context,false}

--- a/configs/logging/default.yaml
+++ b/configs/logging/default.yaml
@@ -1,9 +1,16 @@
-# Logging group: default
+# Logging config that bakes active profile into file names and context.
+# This plays nicely with your rotating file logs + JSONL event stream.
 
-level: INFO
-jsonl_path: logs/events.jsonl
-rotating_log_path: logs/spectramind.log
-rotating_bytes: 10485760  # 10 MiB
-rotating_backups: 5
-console_rich: true
-color: true
+logging:
+  level: ${oc.select:logging.level,INFO}
+  jsonl_events: ${oc.select:logging.jsonl_events,true}
+  file_rotation_mb: ${oc.select:logging.file_rotation_mb,25}
+  file_keep: ${oc.select:logging.file_keep,5}
+  files:
+    # Example paths that include the active profile to keep runs separate by profile
+    text_log: logs/${active_profile}/spectramind.log
+    jsonl_log: logs/${active_profile}/events.jsonl
+  context:
+    project: ${project.name}
+    active_profile: ${active_profile}
+    mode: ${project.mode}

--- a/configs/model/default.yaml
+++ b/configs/model/default.yaml
@@ -1,0 +1,42 @@
+# Model defaults that pull symbolic switches & weighting from the active profile.
+# Your training/decoding code can read these directly.
+
+model:
+  encoder:
+    fgs1: mamba_ssm
+    airs: gat_conv
+  decoder:
+    mean_head: gaussian_ll
+    uncertainty_head: flow_uncertainty
+
+symbolic_loss:
+  enable: ${symbolic.enable}
+  rules: ${symbolic.rules}
+  # A place to map profile weighting strings to numeric weights (can be overridden per-run)
+  weights:
+    # When weighting == "physics_prioritized", for example:
+    physics_prioritized:
+      fft_smoothness: 1.0
+      asymmetry: 0.7
+      photonic_alignment: 1.2
+      energy_conservation: 1.0
+      smoothness: 0.5
+      nonnegativity: 0.5
+    molecular_priority:
+      stoichiometry_balance: 1.2
+      spectral_line_consistency: 1.0
+      nonnegativity: 0.6
+      smoothness: 0.4
+    bio_centric:
+      entropy_minimization: 1.2
+      bio_pathway_consistency: 1.0
+      smoothness: 0.6
+    balanced:
+      smoothness: 0.7
+      fft_smoothness: 0.7
+      stoichiometry_balance: 0.7
+      bio_pathway_consistency: 0.7
+    uniform:
+      default: 0.7
+
+  weighting: ${symbolic.weighting}

--- a/src/spectramind/calibration/pipeline.py
+++ b/src/spectramind/calibration/pipeline.py
@@ -13,6 +13,7 @@ from .check_calibration import CalibrationChecker
 from .logging_utils import log_event
 from .photometry import PhotometryExtractor
 from .uncertainty_calibration import UncertaintyCalibrator
+from spectramind.conf_helpers.profile_wire import apply_profile_wire
 
 log = logging.getLogger(__name__)
 
@@ -72,6 +73,7 @@ if hydra is not None:
         version_base=None, config_path="../../configs", config_name="config_v50"
     )
     def main(cfg: DictConfig) -> None:  # pragma: no cover
+        cfg = apply_profile_wire(cfg)
         pipe = CalibrationPipeline(cfg.get("calibration_pipeline", {}))
         paths = cfg.get("paths", {})
         pipe.run(

--- a/src/spectramind/conf_helpers/profile_wire.py
+++ b/src/spectramind/conf_helpers/profile_wire.py
@@ -1,0 +1,87 @@
+# src/spectramind/conf_helpers/profile_wire.py
+# Purpose: one-call “wire-in” for active profile across CLIs: set seeds, attach
+# profile context to logs, and print a compact profile banner.
+#
+# Usage in any CLI entrypoint (right after you have `cfg` from Hydra):
+#   from spectramind.conf_helpers.profile_wire import apply_profile_wire
+#   cfg = apply_profile_wire(cfg)
+#
+# This keeps all profile glue centralized and avoids duplicating logging/seed logic.
+
+from __future__ import annotations
+import os
+import random
+import time
+from typing import Any
+
+def _set_seeds(seed: int, deterministic: bool) -> None:
+    try:
+        import numpy as np
+    except Exception:
+        np = None
+    try:
+        import torch
+    except Exception:
+        torch = None
+
+    random.seed(seed)
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    if np is not None:
+        np.random.seed(seed)
+    if torch is not None:
+        torch.manual_seed(seed)
+        torch.cuda.manual_seed_all(seed)
+        if deterministic:
+            torch.backends.cudnn.deterministic = True  # type: ignore[attr-defined]
+            torch.backends.cudnn.benchmark = False     # type: ignore[attr-defined]
+
+def _ensure_dirs(cfg: Any) -> None:
+    # Create log dirs that embed the active profile if configured that way
+    try:
+        text_log = cfg.logging.files.text_log
+        jsonl_log = cfg.logging.files.jsonl_log
+        for p in (text_log, jsonl_log):
+            d = os.path.dirname(str(p))
+            if d and not os.path.exists(d):
+                os.makedirs(d, exist_ok=True)
+    except Exception:
+        pass
+
+def _log_profile_banner(cfg: Any) -> None:
+    ap = getattr(cfg, "active_profile", "unknown")
+    proj = getattr(getattr(cfg, "project", object()), "name", "SpectraMind")
+    mode = getattr(getattr(cfg, "project", object()), "mode", "standard")
+    ts = time.strftime("%Y-%m-%d %H:%M:%S")
+    banner = (
+        f"[{ts}] [{proj}] profile={ap} mode={mode} "
+        f"seed={getattr(getattr(cfg, 'reproducibility', object()), 'seed', 42)} "
+        f"deterministic={getattr(getattr(cfg, 'reproducibility', object()), 'deterministic', True)}"
+    )
+    print(banner, flush=True)
+
+def _attach_run_context(cfg: Any) -> None:
+    # Optionally enrich JSONL event stream with profile context if your logger reads env
+    os.environ["SPECTRAMIND_ACTIVE_PROFILE"] = str(getattr(cfg, "active_profile", "unknown"))
+    os.environ["SPECTRAMIND_MODE"] = str(getattr(getattr(cfg, "project", object()), "mode", "standard"))
+    os.environ["SPECTRAMIND_PROJECT"] = str(getattr(getattr(cfg, "project", object()), "name", "SpectraMind"))
+
+def apply_profile_wire(cfg: Any) -> Any:
+    """
+    Apply active-profile wiring:
+      1) set seeds & determinism
+      2) ensure log directories exist (with profile in path if configured)
+      3) print a compact run banner for CLI and CI logs
+      4) attach env context for downstream loggers
+    Returns the same cfg for fluent use.
+    """
+    try:
+        seed = int(cfg.reproducibility.seed)
+        deterministic = bool(cfg.reproducibility.deterministic)
+    except Exception:
+        seed, deterministic = 42, True
+
+    _set_seeds(seed, deterministic)
+    _ensure_dirs(cfg)
+    _log_profile_banner(cfg)
+    _attach_run_context(cfg)
+    return cfg

--- a/src/spectramind/training/train_v50.py
+++ b/src/spectramind/training/train_v50.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 import math
 import os
+import hydra
+from spectramind.conf_helpers.profile_wire import apply_profile_wire
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterator, List, Tuple
@@ -360,3 +362,13 @@ def train(cfg: DictConfig) -> None:
     # cfg.train.*, cfg.model.* expected by this trainer
     trainer = Trainer(cfg)
     trainer.run()
+
+if hydra is not None:
+
+    @hydra.main(version_base=None, config_path="../../configs", config_name="config")
+    def main(cfg: DictConfig) -> None:  # pragma: no cover
+        cfg = apply_profile_wire(cfg)
+        train(cfg)
+
+    if __name__ == "__main__":  # pragma: no cover
+        main()


### PR DESCRIPTION
## Summary
- expose active Hydra profile globally and route logging/diagnostics/calibration/model through it
- add `profile_wire` helper to seed, create log dirs, and print profile banner
- hook calibration pipeline and training script into profile wiring and profile-driven calibration step

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68a004c68e18832aa789bf1b602316c8