### PR TITLE
configs: add Hydra profile wiring and dependent groups

### DIFF
--- a/configs/calibration/steps/corel_plus_temp.yaml
+++ b/configs/calibration/steps/corel_plus_temp.yaml
@@ -1,0 +1,7 @@
+# configs/calibration/steps/corel_plus_temp.yaml
+
+calibration:
+  steps:
+    - { name: standard_pipeline, enabled: true }  # aggregate of standard steps in code
+    - { name: temperature_scaling, enabled: true, params: { per_instrument: true } }
+    - { name: corel_conformalize,  enabled: true, params: { bins: 283, coverage_target: 0.95 } }

--- a/configs/calibration/steps/full.yaml
+++ b/configs/calibration/steps/full.yaml
@@ -1,0 +1,17 @@
+# configs/calibration/steps/full.yaml
+
+calibration:
+  steps:
+    - { name: adc_correction, enabled: true }
+    - { name: nonlinearity,  enabled: true }
+    - { name: dark_subtract, enabled: true }
+    - { name: flat_field,    enabled: true }
+    - { name: cds,           enabled: true }
+    - { name: cosmic_ray_removal, enabled: true }
+    - { name: background_subtract, enabled: true }
+    - { name: photometry,    enabled: true }
+    - { name: trace_extraction, enabled: true }
+    - { name: wavelength_calibration, enabled: true }
+    - { name: normalization, enabled: true }
+    - { name: phase_alignment, enabled: true }
+    - { name: molecular_region_qc, enabled: true, params: { focus_molecules: ["H2O","CH4","CO2"] } }

--- a/configs/calibration/steps/minimal.yaml
+++ b/configs/calibration/steps/minimal.yaml
@@ -1,0 +1,6 @@
+# configs/calibration/steps/minimal.yaml
+
+calibration:
+  steps:
+    - { name: normalization, enabled: true }
+    - { name: phase_alignment, enabled: true }

--- a/configs/calibration/steps/standard.yaml
+++ b/configs/calibration/steps/standard.yaml
@@ -1,0 +1,13 @@
+# configs/calibration/steps/standard.yaml
+
+calibration:
+  steps:
+    - { name: adc_correction, enabled: true }
+    - { name: nonlinearity,  enabled: true }
+    - { name: dark_subtract, enabled: true }
+    - { name: flat_field,    enabled: true }
+    - { name: cds,           enabled: true }
+    - { name: photometry,    enabled: true }
+    - { name: trace_extraction, enabled: true }
+    - { name: normalization, enabled: true }
+    - { name: phase_alignment, enabled: true }

--- a/configs/calibration/steps/symbolic_weighted.yaml
+++ b/configs/calibration/steps/symbolic_weighted.yaml
@@ -1,0 +1,8 @@
+# configs/calibration/steps/symbolic_weighted.yaml
+# Emphasize symbolic regions (e.g., molecular bands) during QC/calibration.
+
+calibration:
+  steps:
+    - { name: standard_pipeline, enabled: true }
+    - { name: molecular_region_qc, enabled: true, params: { focus_molecules: ["H2O","CH4","CO2","CO","NH3","O3"] } }
+    - { name: symbolic_region_weighting, enabled: true, params: { weight_factor: 1.25 } }

--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,51 +1,44 @@
+# configs/config.yaml
 # Master root config for SpectraMind V50 (Hydra)
-# Registers the `profiles` group and makes its fields available globally.
+# Profiles here are group overrides; each profile file selects concrete configs
+# for model, calibration/steps, diagnostics, logging, and symbolic/profiles.
+# Active profile is read from hydra:runtime.choices.profiles for logging/UX.
 
 defaults:
   - hydra/job_logging: default
   - hydra/launcher: basic
   - hydra/sweeper: basic
 
-  # Profiles group: choose the default profile; users can override with profiles=<name>
+  # Register and set default profile (users may switch with `profiles=<name>`)
   - profiles: default
 
-  # Project groups wired to read from the active profile (see their defaults files)
-  - logging: default
-  - diagnostics: default
-  - calibration/steps: default
-  - model: default
+  # Baseline group choices (profiles override these)
+  - model: v50
+  - calibration/steps: standard
+  - diagnostics: basic
+  - logging: standard
+  - symbolic/profiles: default
 
 project:
   name: SpectraMind V50
-  mode: standard  # e.g., standard | leaderboard | ci
+  mode: standard  # standard | leaderboard | ci
 
-# Expose the active profile universally
-active_profile: ${profiles.profile.name}
+# Read the currently selected profile name from Hydra runtime choices.
+# This is robust for the "group override" style of profiles.
+active_profile: ${hydra:runtime.choices.profiles}
 
 reproducibility:
-  seed: ${oc.select:profiles.profile.reproducibility.seed,42}
-  deterministic: ${oc.select:profiles.profile.reproducibility.deterministic,true}
+  seed: 42
+  deterministic: true
 
-# Surface symbolic & diagnostics via profile (downstream groups refine this)
-symbolic:
-  enable: ${profiles.profile.symbolic.enable}
-  rules: ${profiles.profile.symbolic.rules}
-  weighting: ${profiles.profile.symbolic.weighting}
-
-diagnostics:
-  enable_fft: ${oc.select:profiles.profile.diagnostics.enable_fft,false}
-  enable_shap: ${oc.select:profiles.profile.diagnostics.enable_shap,false}
-  enable_symbolic_overlay: ${oc.select:profiles.profile.diagnostics.enable_symbolic_overlay,false}
-  enable_dashboard: ${oc.select:profiles.profile.diagnostics.enable_dashboard,false}
-  enable_interactive_html: ${oc.select:profiles.profile.diagnostics.enable_interactive_html,false}
-  fusion_overlays: ${oc.select:profiles.profile.diagnostics.fusion_overlays,[]}
-  overlays: ${oc.select:profiles.profile.diagnostics.overlays,[]}
-  molecular_templates: ${oc.select:profiles.profile.diagnostics.molecular_templates,[]}
-  molecular_focus: ${oc.select:profiles.profile.diagnostics.molecular_focus,[]}
-  enable_cosmology_context: ${oc.select:profiles.profile.diagnostics.enable_cosmology_context,false}
-
+# Global logging defaults (group files may refine)
 logging:
   level: INFO
   jsonl_events: true
   file_rotation_mb: 25
   file_keep: 5
+
+# Model-wide toggles that components may consult (safe defaults)
+runtime:
+  max_hours: 12
+  save_submission: false

--- a/configs/default.yaml
+++ b/configs/default.yaml
@@ -1,5 +1,5 @@
-# Convenience entry so `-c configs` works even if someone resolves to "default"
-# and you still land on the full root in config.yaml.
+# configs/default.yaml
+# Convenience to ensure resolving "default" lands on the full root "config".
 
 defaults:
   - config

--- a/configs/diagnostics/basic.yaml
+++ b/configs/diagnostics/basic.yaml
@@ -1,0 +1,13 @@
+# configs/diagnostics/basic.yaml
+
+diagnostics:
+  enable_fft: true
+  enable_shap: true
+  enable_symbolic_overlay: true
+  enable_dashboard: false
+  enable_interactive_html: false
+  overlays: []
+  fusion_overlays: []
+  molecular_templates: []
+  molecular_focus: []
+  enable_cosmology_context: false

--- a/configs/diagnostics/explain.yaml
+++ b/configs/diagnostics/explain.yaml
@@ -1,4 +1,4 @@
-# configs/diagnostics/symbolic.yaml
+# configs/diagnostics/explain.yaml
 
 diagnostics:
   enable_fft: true
@@ -6,8 +6,8 @@ diagnostics:
   enable_symbolic_overlay: true
   enable_dashboard: true
   enable_interactive_html: true
-  overlays: ["symbolic_rules", "violation_matrix", "symbolic_influence"]
-  fusion_overlays: ["symbolic"]
+  overlays: ["shap_bars", "umap", "tsne"]
+  fusion_overlays: ["shap", "entropy"]
   molecular_templates: []
   molecular_focus: []
   enable_cosmology_context: false

--- a/configs/diagnostics/leaderboard.yaml
+++ b/configs/diagnostics/leaderboard.yaml
@@ -1,13 +1,13 @@
-# configs/diagnostics/calibration.yaml
+# configs/diagnostics/leaderboard.yaml
 
 diagnostics:
   enable_fft: true
-  enable_shap: false
+  enable_shap: true
   enable_symbolic_overlay: true
   enable_dashboard: true
   enable_interactive_html: true
-  overlays: ["calibration_curves", "coverage_map", "zscore_bins"]
-  fusion_overlays: ["symbolic"]
+  overlays: ["gll_heatmap", "umap", "tsne", "calibration"]
+  fusion_overlays: ["symbolic", "shap", "entropy"]
   molecular_templates: ["H2O", "CH4", "CO2"]
   molecular_focus: ["H2O", "CH4", "CO2"]
-  enable_cosmology_context: false
+  enable_cosmology_context: true

--- a/configs/diagnostics/lite.yaml
+++ b/configs/diagnostics/lite.yaml
@@ -1,0 +1,13 @@
+# configs/diagnostics/lite.yaml
+
+diagnostics:
+  enable_fft: false
+  enable_shap: false
+  enable_symbolic_overlay: false
+  enable_dashboard: false
+  enable_interactive_html: false
+  overlays: []
+  fusion_overlays: []
+  molecular_templates: []
+  molecular_focus: []
+  enable_cosmology_context: false

--- a/configs/logging/debug.yaml
+++ b/configs/logging/debug.yaml
@@ -1,0 +1,14 @@
+# configs/logging/debug.yaml
+
+logging:
+  level: DEBUG
+  jsonl_events: true
+  file_rotation_mb: 20
+  file_keep: 3
+  files:
+    text_log: logs/${active_profile}/debug.log
+    jsonl_log: logs/${active_profile}/debug_events.jsonl
+  context:
+    project: ${project.name}
+    active_profile: ${active_profile}
+    mode: ${project.mode}

--- a/configs/logging/mission.yaml
+++ b/configs/logging/mission.yaml
@@ -1,0 +1,14 @@
+# configs/logging/mission.yaml
+
+logging:
+  level: INFO
+  jsonl_events: true
+  file_rotation_mb: 15
+  file_keep: 10
+  files:
+    text_log: logs/${active_profile}/mission.log
+    jsonl_log: logs/${active_profile}/mission_events.jsonl
+  context:
+    project: ${project.name}
+    active_profile: ${active_profile}
+    mode: leaderboard

--- a/configs/logging/standard.yaml
+++ b/configs/logging/standard.yaml
@@ -1,0 +1,14 @@
+# configs/logging/standard.yaml
+
+logging:
+  level: ${oc.select:logging.level,INFO}
+  jsonl_events: ${oc.select:logging.jsonl_events,true}
+  file_rotation_mb: ${oc.select:logging.file_rotation_mb,25}
+  file_keep: ${oc.select:logging.file_keep,5}
+  files:
+    text_log: logs/${active_profile}/spectramind.log
+    jsonl_log: logs/${active_profile}/events.jsonl
+  context:
+    project: ${project.name}
+    active_profile: ${active_profile}
+    mode: ${project.mode}

--- a/configs/logging/symbolic.yaml
+++ b/configs/logging/symbolic.yaml
@@ -1,0 +1,14 @@
+# configs/logging/symbolic.yaml
+
+logging:
+  level: INFO
+  jsonl_events: true
+  file_rotation_mb: 25
+  file_keep: 5
+  files:
+    text_log: logs/${active_profile}/symbolic.log
+    jsonl_log: logs/${active_profile}/symbolic_events.jsonl
+  context:
+    project: ${project.name}
+    active_profile: ${active_profile}
+    mode: ${project.mode}

--- a/configs/logging/verbose.yaml
+++ b/configs/logging/verbose.yaml
@@ -1,0 +1,14 @@
+# configs/logging/verbose.yaml
+
+logging:
+  level: TRACE
+  jsonl_events: true
+  file_rotation_mb: 50
+  file_keep: 2
+  files:
+    text_log: logs/${active_profile}/verbose.log
+    jsonl_log: logs/${active_profile}/verbose_events.jsonl
+  context:
+    project: ${project.name}
+    active_profile: ${active_profile}
+    mode: ${project.mode}

--- a/configs/model/v50.yaml
+++ b/configs/model/v50.yaml
@@ -1,0 +1,25 @@
+# configs/model/v50.yaml
+# SpectraMind V50 default model blueprint identifiers and high-level knobs.
+# Concrete hyperparameters live in code or richer sub-groups; these act as stable keys.
+
+model:
+  encoder:
+    fgs1: mamba_ssm            # long-seq encoder for FGS1
+    airs: gat_conv             # edge-feature-aware GNN for AIRS
+  decoder:
+    mean_head: gaussian_ll     # μ decoder optimized for Gaussian log-likelihood
+    uncertainty_head: flow_uncertainty  # σ head with flow/attention fusion
+  training:
+    amp: true
+    epochs: 40
+    batch_size: 16
+    optimizer: adamw
+    lr: 3.0e-4
+    weight_decay: 0.05
+    cosine_decay: true
+  calibration:
+    enable_corel: true
+    enable_temp_scaling: true
+  exports:
+    save_best_by: gll
+    keep_last_k: 3

--- a/configs/profiles/README.md
+++ b/configs/profiles/README.md
@@ -1,35 +1,37 @@
-# configs/profiles
+# configs/profiles — Scenario Bundles (Hydra)
 
-This directory defines **symbolic and diagnostic profiles** for SpectraMind V50 using Hydra’s configuration grouping.
+These profiles are **Hydra override bundles** that select concrete group configs for:
 
-## Purpose
-Profiles provide domain-specific configurations for symbolic rules, diagnostics, and reproducibility. They enable modular switching between astrophysics, chemistry, biology, cross-disciplinary, and GUI-focused modes.
+* `model` (e.g., `configs/model/v50.yaml`)
+* `calibration/steps` (e.g., `minimal`, `standard`, `full`, `corel_plus_temp`, `symbolic_weighted`)
+* `diagnostics` (e.g., `basic`, `lite`, `leaderboard`, `symbolic`, `explain`, `calibration`)
+* `logging` (e.g., `standard`, `debug`, `mission`, `symbolic`, `verbose`)
+* `symbolic/profiles` (e.g., `default`, `strict`, `relaxed`, `exploratory`)
 
-## Available Profiles
-- **default.yaml** – Baseline symbolic and diagnostic settings.
-- **astrophysics.yaml** – Physics-informed rules (FFT smoothness, photonic alignment, cosmology overlays).
-- **chemistry.yaml** – Quantum chemistry and molecular line constraints.
-- **biology.yaml** – Symbolic entropy and pathway consistency checks for biological systems.
-- **cross_disciplinary.yaml** – Fusion across AI, physics, chemistry, biology.
-- **gui.yaml** – Diagnostic/visualization overlays for dashboards.
+Available profiles:
 
-## Usage
-To activate a profile in Hydra CLI:
-```bash
-python train_v50.py profiles=astrophysics
-python diagnose_v50.py profiles=gui
-```
+* `default.yaml` — balanced defaults for research/testing, reproducible.
+* `fast_dev.yaml` — faster runs; minimal calibration & diagnostics, debug logs.
+* `kaggle_leaderboard.yaml` — mission-grade rigor for challenge submissions (≤9h).
+* `symbolic_strict.yaml` — hard enforcement of symbolic rules.
+* `explainability.yaml` — SHAP, UMAP, t-SNE, overlays & dashboards.
+* `calibration_heavy.yaml` — COREL + temperature scaling focus, coverage-first.
 
-## References
+### Usage
 
-Profiles are informed by:
+Activate any profile with:
 
-* Documentation-first protocol
-* Patterns, algorithms, fractals reference
-* NASA-grade scientific modeling
-* Physics & astrophysics modeling
-* Chemistry & biology foundations
-* Engineering guide to GUI systems
-* Foundational templates & glossary
-* Domain module examples
-* Ariel mission science context
+* Python module:
+  * `python -m spectramind.cli.spectramind train profiles=kaggle_leaderboard`
+  * `python -m spectramind.cli.spectramind diagnose dashboard profiles=explainability`
+* Direct script:
+  * `python src/spectramind/train_v50.py profiles=symbolic_strict`
+  * `python src/spectramind/predict_v50.py profiles=default`
+
+The active profile name is exposed as `${active_profile}` (from Hydra runtime), which is embedded in log paths and context.
+
+### Notes
+
+* Profiles merge with `configs/config.yaml`; they can override `reproducibility`, `project.mode`, etc.
+* Groups are designed to be orthogonal and composable.
+* Add new profiles by composing `defaults` with existing or new group files.

--- a/configs/profiles/calibration_heavy.yaml
+++ b/configs/profiles/calibration_heavy.yaml
@@ -1,0 +1,18 @@
+# configs/profiles/calibration_heavy.yaml
+# Emphasize uncertainty calibration (COREL + temperature scaling) and coverage.
+
+defaults:
+  - override /model: v50
+  - override /calibration/steps: corel_plus_temp
+  - override /diagnostics: calibration
+  - override /logging: mission
+  - override /symbolic/profiles: default
+
+calibration:
+  corel_bins: 283
+  coverage_target: 0.95
+  temp_scaling: true
+
+reproducibility:
+  seed: 606
+  deterministic: true

--- a/configs/profiles/default.yaml
+++ b/configs/profiles/default.yaml
@@ -1,26 +1,13 @@
-# Default symbolic/diagnostic profile for SpectraMind V50
-# This profile acts as a baseline across all domains.
-# Hydra group: profiles=default
+# configs/profiles/default.yaml
+# Balanced default profile for research & testing; reproducible by default.
 
 defaults:
-  - override hydra/job_logging: default
-  - override hydra/launcher: basic
-  - override hydra/sweeper: basic
+  - override /model: v50
+  - override /calibration/steps: standard
+  - override /diagnostics: basic
+  - override /logging: standard
+  - override /symbolic/profiles: default
 
-profile:
-  name: default
-  description: |
-    Default SpectraMind V50 symbolic profile.
-    Uses general symbolic rules, FFT smoothness, entropy checks,
-    and calibration diagnostics.
-  symbolic:
-    enable: true
-    rules: ["smoothness", "nonnegativity", "entropy"]
-    weighting: "uniform"
-  diagnostics:
-    enable_fft: true
-    enable_shap: true
-    enable_symbolic_overlay: true
-  reproducibility:
-    seed: 42
-    deterministic: true
+reproducibility:
+  seed: 42
+  deterministic: true

--- a/configs/profiles/explainability.yaml
+++ b/configs/profiles/explainability.yaml
@@ -1,0 +1,18 @@
+# configs/profiles/explainability.yaml
+# Focus on SHAP, UMAP/t-SNE, and overlay-driven diagnostics & dashboards.
+
+defaults:
+  - override /model: v50
+  - override /calibration/steps: standard
+  - override /diagnostics: explain
+  - override /logging: verbose
+  - override /symbolic/profiles: exploratory
+
+explainability:
+  run_shap: true
+  run_umap: true
+  run_tsne: true
+
+reproducibility:
+  seed: 31415
+  deterministic: true

--- a/configs/profiles/fast_dev.yaml
+++ b/configs/profiles/fast_dev.yaml
@@ -1,0 +1,18 @@
+# configs/profiles/fast_dev.yaml
+# Minimal pipeline for rapid iterations and local debugging.
+
+defaults:
+  - override /model: v50
+  - override /calibration/steps: minimal
+  - override /diagnostics: lite
+  - override /logging: debug
+  - override /symbolic/profiles: relaxed
+
+reproducibility:
+  seed: 123
+  deterministic: false
+
+hydra:
+  sweeper:
+    params:
+      +fast_dev: true

--- a/configs/profiles/kaggle_leaderboard.yaml
+++ b/configs/profiles/kaggle_leaderboard.yaml
@@ -1,0 +1,20 @@
+# configs/profiles/kaggle_leaderboard.yaml
+# Mission-grade rigor for NeurIPS Ariel Challenge submissions (<= 9 hours).
+
+defaults:
+  - override /model: v50
+  - override /calibration/steps: full
+  - override /diagnostics: leaderboard
+  - override /logging: mission
+  - override /symbolic/profiles: strict
+
+runtime:
+  max_hours: 9
+  save_submission: true
+
+reproducibility:
+  seed: 2025
+  deterministic: true
+
+project:
+  mode: leaderboard

--- a/configs/profiles/symbolic_strict.yaml
+++ b/configs/profiles/symbolic_strict.yaml
@@ -1,0 +1,13 @@
+# configs/profiles/symbolic_strict.yaml
+# Hard emphasis on symbolic rule compliance and diagnostics.
+
+defaults:
+  - override /model: v50
+  - override /calibration/steps: symbolic_weighted
+  - override /diagnostics: symbolic
+  - override /logging: symbolic
+  - override /symbolic/profiles: strict
+
+reproducibility:
+  seed: 777
+  deterministic: true

--- a/configs/symbolic/profiles/default.yaml
+++ b/configs/symbolic/profiles/default.yaml
@@ -1,14 +1,14 @@
+# configs/symbolic/profiles/default.yaml
+
 symbolic:
-  profile:
-    name: "default"
-    description: "Balanced symbolic settings for general training and validation."
-    normalize: true
-    mode: "soft"
-    export_detail: "summary"     # ["none","summary","full"]
-    toggles:
-      export_fft_power: true
-      export_alignment: true
-      export_per_molecule: true
-      export_violation_maps: true
-    caps:
-      per_rule_cap: 10.0
+  enable: true
+  rules:
+    - smoothness
+    - nonnegativity
+    - entropy
+  weights:
+    smoothness: 0.7
+    nonnegativity: 0.7
+    entropy: 0.7
+  enforce_hard: false
+  violation_penalty: 1.0

--- a/configs/symbolic/profiles/exploratory.yaml
+++ b/configs/symbolic/profiles/exploratory.yaml
@@ -1,0 +1,16 @@
+# configs/symbolic/profiles/exploratory.yaml
+
+symbolic:
+  enable: true
+  rules:
+    - smoothness
+    - visual_smoothness
+    - attention_overlay
+    - entropy
+  weights:
+    smoothness: 0.6
+    visual_smoothness: 0.6
+    attention_overlay: 0.6
+    entropy: 0.6
+  enforce_hard: false
+  violation_penalty: 0.8

--- a/configs/symbolic/profiles/relaxed.yaml
+++ b/configs/symbolic/profiles/relaxed.yaml
@@ -1,0 +1,12 @@
+# configs/symbolic/profiles/relaxed.yaml
+
+symbolic:
+  enable: true
+  rules:
+    - smoothness
+    - nonnegativity
+  weights:
+    smoothness: 0.4
+    nonnegativity: 0.4
+  enforce_hard: false
+  violation_penalty: 0.5

--- a/configs/symbolic/profiles/strict.yaml
+++ b/configs/symbolic/profiles/strict.yaml
@@ -1,0 +1,18 @@
+# configs/symbolic/profiles/strict.yaml
+
+symbolic:
+  enable: true
+  rules:
+    - fft_smoothness
+    - asymmetry
+    - photonic_alignment
+    - energy_conservation
+    - nonnegativity
+  weights:
+    fft_smoothness: 1.0
+    asymmetry: 0.7
+    photonic_alignment: 1.2
+    energy_conservation: 1.0
+    nonnegativity: 0.8
+  enforce_hard: true
+  violation_penalty: 10.0


### PR DESCRIPTION
## Summary
- establish root Hydra config with active profile resolution
- add profiles and dependent config groups for diagnostics, logging, calibration and symbolic rules
- document available profiles and usage

## Testing
- `pre-commit run --files $(git ls-files -m -o --exclude-standard | tr '\n' ' ')`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a0070f9bf4832a9be8c6a718a069dc