### PR TITLE
Add Hydra runtime helpers and CLI runtime wiring

### DIFF
--- a/src/spectramind/conf_helpers/runtime.py
+++ b/src/spectramind/conf_helpers/runtime.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+"""
+SpectraMind V50 — Hydra runtime wiring helpers.
+
+This module centralizes how the CLI injects a Hydra group override for runtime=<name>,
+so that any command (train, predict, diagnose, submit, etc.) can honor a user-chosen
+execution context like: local, kaggle, hpc, docker, ci.
+
+Design goals:
+    • Single source of truth for a “runtime” override that is guaranteed to be applied.
+    • Zero-conf for callers: call compose_with_runtime() and pass optional extra overrides.
+    • Deterministic and reproducible: logs the chosen runtime and the absolute config path used.
+    • Backward compatible: if no runtime is provided via CLI or env, falls back to “default”.
+
+Usage:
+from spectramind.conf_helpers.runtime import (
+    determine_runtime,
+    compose_with_runtime,
+    log_runtime_choice,
+)
+
+runtime = determine_runtime(cli_runtime)  # cli_runtime may be None
+cfg = compose_with_runtime(runtime, overrides=["model=v50/fgs1_mamba", "calibration=corel"])
+log_runtime_choice(runtime, cfg)
+
+Hydra configuration requirements:
+    • A config group exists at configs/runtime with files: default.yaml, local.yaml, kaggle.yaml, hpc.yaml, docker.yaml, ci.yaml
+    • The CLI should pass the override runtime=<name> whenever it composes a config.
+"""
+
+import os
+import pathlib
+import datetime
+from typing import Iterable, List, Optional
+
+from omegaconf import DictConfig, OmegaConf
+
+# Hydra is imported lazily inside compose_with_runtime to avoid global initialization side effects.
+
+# Environment variable used to propagate runtime across sub-commands when the root CLI
+# sets it once (e.g., spectramind --runtime kaggle submit make-submission).
+_ENV_RUNTIME = "SPECTRAMIND_RUNTIME"
+
+
+def determine_runtime(cli_value: Optional[str]) -> str:
+    """
+    Resolve the runtime name from (in order of precedence):
+    1) Explicit CLI value (if provided and non-empty)
+    2) Environment variable SPECTRAMIND_RUNTIME (if set)
+    3) Fallback to "default"
+
+    Parameters
+    ----------
+    cli_value : Optional[str]
+        A string passed from the CLI option/flag, e.g., "--runtime kaggle".
+
+    Returns
+    -------
+    str
+        The resolved runtime name to be used for Hydra overrides.
+    """
+    if cli_value and str(cli_value).strip():
+        runtime = str(cli_value).strip()
+    else:
+        runtime = os.environ.get(_ENV_RUNTIME, "").strip() or "default"
+    # Normalize to lowercase for consistency
+    return runtime.lower()
+
+
+def set_runtime_env(runtime: str) -> None:
+    """
+    Persist the runtime selection to the process environment so that nested CLIs
+    and subprocesses see the same choice without re-specifying it.
+    """
+    os.environ[_ENV_RUNTIME] = runtime
+
+
+def _now_iso() -> str:
+    return datetime.datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _project_root() -> pathlib.Path:
+    """
+    Attempt to discover the repo root by walking up until we find a 'configs' directory.
+    Fallback to CWD if not found.
+    """
+    p = pathlib.Path.cwd()
+    for _ in range(10):
+        if (p / "configs").exists():
+            return p
+        p = p.parent
+    return pathlib.Path.cwd()
+
+
+def compose_with_runtime(runtime: str, overrides: Optional[Iterable[str]] = None) -> DictConfig:
+    """
+    Compose a Hydra config with the given runtime override, plus any additional overrides.
+
+    This function initializes Hydra in a context-managed way so repeated calls from the same
+    process are safe. It uses the project's `configs/` directory as the search path.
+
+    Parameters
+    ----------
+    runtime : str
+        The runtime choice (e.g., "default", "local", "kaggle", "hpc", "docker", "ci").
+    overrides : Optional[Iterable[str]]
+        Any additional Hydra overrides to include in the composition.
+
+    Returns
+    -------
+    DictConfig
+        A composed Hydra config with `runtime=<name>` applied.
+    """
+    # Lazy import to avoid global Hydra initialization on module import.
+    from hydra import initialize_config_dir, compose
+
+    root = _project_root()
+    config_dir = str(root / "configs")
+
+    all_overrides: List[str] = [f"runtime={runtime}"]
+    if overrides:
+        all_overrides.extend(list(overrides))
+
+    # Initialize Hydra with explicit config_dir to avoid ambiguity in packaged installs.
+    with initialize_config_dir(config_dir=config_dir, job_name=f"compose:{runtime}"):
+        cfg = compose(config_name="config", overrides=all_overrides)
+
+    return cfg
+
+
+def log_runtime_choice(runtime: str, cfg: Optional[DictConfig], extra_note: Optional[str] = None) -> None:
+    """
+    Append a minimal, structured line to v50_debug_log.md so we always have an auditable
+    record of how the CLI was executed with regard to runtime choice.
+
+    Format (single line, Markdown table friendly):
+        2025-08-15T22:59:00Z | runtime=kaggle | config_root=/abs/path/configs | note=...
+
+    This function is intentionally lightweight and never raises; any exceptions are swallowed
+    so it does not interfere with the primary CLI action.
+    """
+    try:
+        root = _project_root()
+        log_path = root / "v50_debug_log.md"
+        config_root = str((_project_root() / "configs").resolve())
+
+        line = f"{_now_iso()} | runtime={runtime} | config_root={config_root}"
+        if extra_note:
+            line += f" | note={extra_note}"
+
+        line += "\n"
+
+        # Ensure file exists with a header on first write.
+        if not log_path.exists():
+            header = (
+                "# SpectraMind V50 — Debug Log\n"
+                "| timestamp (UTC) | runtime | config_root | note |\n"
+                "|---|---|---|---|\n"
+            )
+            with log_path.open("w", encoding="utf-8") as f:
+                f.write(header)
+
+        with log_path.open("a", encoding="utf-8") as f:
+            # Convert the simple line to a Markdown row for readability.
+            parts = [p.strip() for p in line.strip().split("|")]
+            # Expecting: ["2025-...", " runtime=...", " config_root=...", " note=..."]
+            # Normalize to cells without keys for compactness, but keep values visible.
+            ts = parts[0]
+            rv = parts[1].split("=", 1)[1] if len(parts) > 1 and "=" in parts[1] else ""
+            cr = parts[2].split("=", 1)[1] if len(parts) > 2 and "=" in parts[2] else ""
+            nt = parts[3].split("=", 1)[1] if len(parts) > 3 and "=" in parts[3] else ""
+            f.write(f"| {ts} | {rv} | {cr} | {nt} |\n")
+    except Exception:
+        # Never break the CLI; logging is best-effort.
+        pass
+
+
+def pretty_print_cfg(cfg: DictConfig) -> None:
+    """
+    Convenience function to print the composed configuration to stdout
+    in a deterministic way for quick debugging or verification.
+    """
+    print(OmegaConf.to_yaml(cfg, resolve=True))

--- a/src/spectramind/selftest.py
+++ b/src/spectramind/selftest.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""
+SpectraMind V50 — Self-test runner with runtime wiring.
+
+This module composes a Hydra config with the selected runtime override and performs
+a set of lightweight checks to verify that critical files, config groups, and CLI entries
+are present and importable. It is intentionally fast and safe to run in CI.
+
+Return codes:
+0: success
+1: failure detected
+"""
+
+import importlib
+import sys
+from typing import Optional, List
+
+from spectramind.conf_helpers.runtime import (
+    determine_runtime,
+    set_runtime_env,
+    compose_with_runtime,
+    log_runtime_choice,
+)
+
+
+def _check_import(module: str, errors: List[str]) -> None:
+    try:
+        importlib.import_module(module)
+    except Exception as e:
+        errors.append(f"Import failed: {module} -> {e}")
+
+
+def main(cli_runtime: Optional[str] = None) -> int:
+    """
+    Entry point callable by the root CLI or programmatically.
+    """
+    runtime = determine_runtime(cli_runtime)
+    set_runtime_env(runtime)
+    cfg = compose_with_runtime(runtime, overrides=[])
+    log_runtime_choice(runtime, cfg, extra_note="selftest.main")
+
+    errors: List[str] = []
+
+    # Minimal presence checks for frequently used modules. Extend as needed.
+    _check_import("spectramind.cli.cli_core_v50", errors)
+    _check_import("spectramind.cli.cli_submit", errors)
+    _check_import("spectramind.cli.cli_diagnose", errors)
+    _check_import("spectramind.conf_helpers.runtime", errors)
+
+    # Sanity check that the composed config includes a 'runtime' group resolution.
+    try:
+        resolved = cfg.get("runtime", {})
+        if not resolved or not isinstance(resolved, dict):
+            errors.append("Composed config missing 'runtime' group resolution.")
+        else:
+            # Require a name field to be present (as set in configs/runtime/*.yaml).
+            name = resolved.get("name", None)
+            if not name:
+                errors.append("Composed runtime config lacks 'name' field.")
+    except Exception as e:
+        errors.append(f"Failed to access runtime config in composed cfg: {e}")
+
+    if errors:
+        for e in errors:
+            print(f"[SELFTEST][FAIL] {e}")
+        return 1
+
+    print("[SELFTEST][OK] CLI + runtime wiring is healthy.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(None))
+

--- a/src/spectramind/spectramind.py
+++ b/src/spectramind/spectramind.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+"""
+SpectraMind V50 — Root Typer CLI with global --runtime wiring.
+
+This file registers sub-CLIs and ensures that any command run beneath the root
+inherits the chosen runtime environment (Hydra group override runtime=<name>).
+
+Sub-CLIs mounted:
+    • core   : Training / inference / utilities (cli_core_v50)
+    • submit : Submission orchestration (cli_submit)
+    • diagnose: Diagnostics, dashboards, explainability (cli_diagnose)
+    • test   : Self-test runner (spectramind test) for quick repository integrity checks
+
+Global options:
+--runtime [default|local|kaggle|hpc|docker|ci]
+Applies a Hydra override runtime=<name> across all subcommands and calls.
+"""
+
+import os
+import sys
+from typing import Optional
+
+import typer
+
+from spectramind.conf_helpers.runtime import (
+    determine_runtime,
+    set_runtime_env,
+    log_runtime_choice,
+)
+
+# Import sub-apps (they themselves also accept/resolve --runtime, but mounting them
+# under this root enables a single global flag to apply everywhere).
+from spectramind.cli import cli_core_v50 as _cli_core_v50
+from spectramind.cli import cli_submit as _cli_submit
+from spectramind.cli import cli_diagnose as _cli_diagnose
+
+app = typer.Typer(help="SpectraMind V50 — Unified CLI (root)", add_completion=True)
+
+
+def _version_line() -> str:
+    """
+    Return a compact version string. We avoid heavy imports here.
+    Extend this function to include run hash if you maintain run_hash_summary_v50.json.
+    """
+    cli_version = "v50"
+    return f"SpectraMind CLI {cli_version}"
+
+
+@app.callback()
+def main(
+    ctx: typer.Context,
+    runtime: Optional[str] = typer.Option(
+        None,
+        "--runtime",
+        "-r",
+        help="Select execution environment (Hydra group): default|local|kaggle|hpc|docker|ci",
+    ),
+    version: bool = typer.Option(False, "--version", help="Show CLI version and exit"),
+):
+    """
+    Root callback runs once and sets SPECTRAMIND_RUNTIME so all nested Typer apps
+    and subprocesses inherit it. This achieves a global 'runtime' switch behavior.
+    """
+    if version:
+        typer.echo(_version_line())
+        raise typer.Exit(0)
+
+    resolved_runtime = determine_runtime(runtime)
+    set_runtime_env(resolved_runtime)
+    # Lightweight, best-effort log line (will not raise if file permissions are restricted).
+    log_runtime_choice(resolved_runtime, cfg=None, extra_note="root-cli")  # cfg is optional here
+
+
+# Mount sub-CLIs under the root.
+app.add_typer(_cli_core_v50.app, name="core", help="Core training/inference CLI")
+app.add_typer(_cli_submit.app, name="submit", help="Submission orchestration CLI")
+app.add_typer(_cli_diagnose.app, name="diagnose", help="Diagnostics and dashboard CLI")
+
+
+@app.command("test")
+def run_selftest(
+    runtime: Optional[str] = typer.Option(
+        None, "--runtime", "-r", help="Override execution environment for the self-test"
+    ),
+):
+    """
+    Execute repository self-checks. Honors the same global runtime selection.
+    """
+    # Re-resolve runtime if provided here; otherwise use ENV set by root callback.
+    from spectramind.conf_helpers.runtime import determine_runtime, set_runtime_env, log_runtime_choice
+
+    resolved_runtime = determine_runtime(runtime)
+    set_runtime_env(resolved_runtime)
+    log_runtime_choice(resolved_runtime, cfg=None, extra_note="selftest")
+
+    # Defer import to keep CLI import time minimal.
+    try:
+        from spectramind.selftest import main as selftest_main
+    except Exception as e:
+        typer.echo(f"[ERROR] Failed to import selftest module: {e}", err=True)
+        raise typer.Exit(1)
+
+    # Execute the self-test routine (it composes Hydra configs with runtime override internally).
+    exit_code = selftest_main()
+    raise typer.Exit(exit_code)
+
+
+if __name__ == "__main__":
+    app()
+


### PR DESCRIPTION
## Summary
- centralize runtime resolution and logging helpers
- wire global runtime flag into Typer root CLI
- update core, submit, and diagnose CLIs to compose configs with runtime
- add lightweight self-test exercising runtime wiring

## Testing
- `pytest -q` *(fails: IndexError in photonic alignment and asymmetry rules)*


------
https://chatgpt.com/codex/tasks/task_e_68a00d147cf4832aaf3c2e21af42668d