### PR TITLE
Add hydra-core dependency for logging tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pyyaml>=6.0
 jsonschema>=4.22
+hydra-core>=1.3
 # mlflow>=2.12  # optional
 # wandb>=0.17  # optional
 mlflow>=2.14.0 # optional; used if installed


### PR DESCRIPTION
## Summary
- Add hydra-core to requirements so Hydra logging config tests run

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a08a7d4c9c832ab34636bddf49e45e