### PR TITLE
feat(train): add mission-ready training stack

### DIFF
--- a/src/spectramind/train/README.md
+++ b/src/spectramind/train/README.md
@@ -1,0 +1,50 @@
+# SpectraMind V50 — `src/spectramind/train`
+
+Mission-grade training package for the NeurIPS 2025 Ariel Data Challenge (V50 stack).
+
+## Features
+
+* Deterministic seeding and environment capture
+* Console + rotating file logs and a JSONL event stream
+* Optional MLflow sync (`run.mlflow: true`)
+* Hydra/OmegaConf-friendly config dicts; no hard dependency on Hydra to execute
+* Flexible registry builders for datasets, models, losses, optimizers, schedulers, and step processors
+* Robust `TrainerBase` with AMP, gradient accumulation, checkpointing, and early stopping
+* Built-in dummy dataset/model for smoke testing
+* `selftest.py` to validate the package in isolation
+
+## Quick Start (Dummy Smoke Test)
+
+```bash
+python -m src.spectramind.train.train_v50
+# or
+python -m src.spectramind.train.selftest
+```
+
+Artifacts appear under `runs/...` including `train.log` (rotating text log) and `events.jsonl` (JSONL event stream).
+
+## Integrating with the CLI
+
+The `run_train(cfg: Dict[str, Any])` functions are designed to be called from SpectraMind’s Typer CLI modules:
+
+* General supervised: `train_v50.run_train(cfg)`
+* MAE pretrain: `train_mae_v50.run_train(cfg)`
+* Contrastive pretrain: `train_contrastive_v50.run_train(cfg)`
+
+## Config Schema (Example)
+
+See the inline example at the top of `train_v50.py`. Minimal fields:
+
+* `run`: name, out_dir, seed, device, mlflow flags
+* `data`: dataset targets for train/val + dataloader options
+* `model`: target + params
+* `loss`: main + optional smooth/asym with weights
+* `optim`: name/lr/weight_decay
+* `sched`: scheduler config (cosine_warmup/onecycle/step/none)
+* `train`: epochs, grad_accum, amp, clip_grad_norm, patience
+
+## Reproducibility
+
+* Config snapshots saved to `<out_dir>/config_snapshot.yaml`
+* Git hash captured when available
+* Logs and JSONL stream suitable for CI parsing

--- a/src/spectramind/train/__init__.py
+++ b/src/spectramind/train/__init__.py
@@ -1,44 +1,41 @@
-from __future__ import annotations
-
 """
-SpectraMind V50 — Training Package (src/spectramind/train)
+SpectraMind V50 - Training Package
+==================================
 
-This package provides unified, Hydra-safe, CLI-integrable training pipelines for the
-NeurIPS 2025 Ariel Data Challenge (SpectraMind V50). It includes:
+This package provides mission-grade training utilities for the NeurIPS Ariel Data Challenge 2025:
 
-* train_v50.py:         Full μ/σ supervised training loop with physics-aware losses.
-* train_mae_v50.py:     Masked Autoencoder (MAE) pretraining for spectral/time cubes.
-* train_contrastive_v50.py: Contrastive pretraining on latent embeddings.
-* corel_train.py:       COREL bin-wise conformal calibration training (GNN-ready).
-* callbacks.py:         Early stopping, checkpointing, and graceful failover hooks.
-* schedulers.py:        Cosine annealing with warmup; step and plateau schedulers.
-* losses.py:            Gaussian log-likelihood (GLL), L2 smoothness, FFT penalties,
-  symbolic wrapper hooks for physics-informed constraints.
-* logger.py:            Console + rotating file logs + JSONL event stream + MLflow/W&B optional.
-* common.py:            Deterministic seeding, device selection, checkpoint utils, hash capture.
-* data_loading.py:      Thin data adapters and dataset registry plumbing.
-* selftest_train_pkg.py: Coherence checks for this package (imports, shapes, I/O).
+* Deterministic seeding and environment capture
+* Console + rotating file logs AND JSONL event stream
+* Optional MLflow/W&B sync (MLflow integrated; W&B can be added similarly)
+* Hydra/OmegaConf-friendly builders (datasets, models, losses, optimizers, schedulers, step processors)
+* Robust TrainerBase with AMP, grad accumulation, checkpointing, early stopping, and reproducibility
+* Self-test harness for quick validation of the stack
 
-All modules write reproducibility metadata to `v50_debug_log.md` and support structured
-JSONL logging for post-hoc analytics and dashboards.
+Primary public entry points:
 
-Conventions:
+* train_v50.run_train(cfg)  -> general supervised training
+* train_mae_v50.run_train(cfg)  -> masked autoencoder pretraining
+* train_contrastive_v50.run_train(cfg) -> contrastive pretraining
 
-* Do NOT import heavy frameworks at module import unless necessary. Delay where possible.
-* Always provide rich docstrings and explicit typing.
-* Every public function logs via the unified logger when meaningful.
-
-Note:
-This package intentionally keeps *no* project-specific absolute paths; it relies on Hydra
-configs and the caller's working directory.
+These functions are designed to be called from CLI modules (e.g., spectramind CLI).
 """
+
+from .utils import seed_everything, get_device, count_parameters, dump_yaml_safely
+from .experiment_logger import ExperimentLogger
+from .trainer_base import TrainerBase, TrainerHooks
+from .callbacks import EarlyStopping, CheckpointManager
+from .optim import build_optimizer, build_scheduler
+from .losses import GaussianLikelihoodLoss, SmoothnessLoss, AsymmetryLoss, CompositeLoss
+from .registry import build_from_target, resolve_callable
+from .step_processors import GenericGaussianProcessor
 
 __all__ = [
-    "common",
-    "logger",
-    "losses",
-    "schedulers",
-    "callbacks",
-    "data_loading",
+    "seed_everything", "get_device", "count_parameters", "dump_yaml_safely",
+    "ExperimentLogger",
+    "TrainerBase", "TrainerHooks",
+    "EarlyStopping", "CheckpointManager",
+    "build_optimizer", "build_scheduler",
+    "GaussianLikelihoodLoss", "SmoothnessLoss", "AsymmetryLoss", "CompositeLoss",
+    "build_from_target", "resolve_callable",
+    "GenericGaussianProcessor",
 ]
-

--- a/src/spectramind/train/experiment_logger.py
+++ b/src/spectramind/train/experiment_logger.py
@@ -1,0 +1,132 @@
+import json
+import logging
+import os
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .utils import RunContext, ensure_dir
+
+try:
+    import mlflow
+except Exception:  # pragma: no cover - mlflow optional
+    mlflow = None  # type: ignore
+
+
+class ExperimentLogger:
+    """
+    Mission-grade experiment logger with:
+    - Console + rotating file logs
+    - JSONL event stream
+    - Optional MLflow run (if mlflow installed and enabled)
+    - Environment capture & run context snapshot
+    """
+
+    def __init__(
+        self,
+        run_name: str,
+        log_dir: str = "runs",
+        jsonl_name: str = "events.jsonl",
+        text_log_name: str = "train.log",
+        mlflow_enable: bool = False,
+        mlflow_experiment: Optional[str] = None,
+        console_level: int = logging.INFO,
+    ) -> None:
+        ensure_dir(log_dir)
+        self.run_name = run_name
+        self.log_dir = str(Path(log_dir).resolve())
+        self.jsonl_path = str(Path(self.log_dir) / jsonl_name)
+        self.text_log_path = str(Path(self.log_dir) / text_log_name)
+        self.console_level = console_level
+
+        # python logging
+        self.logger = logging.getLogger(run_name)
+        self.logger.setLevel(logging.DEBUG)
+        self.logger.propagate = False
+        # Remove existing handlers to avoid duplication on repeated init
+        for h in list(self.logger.handlers):
+            self.logger.removeHandler(h)
+
+        ch = logging.StreamHandler()
+        ch.setLevel(console_level)
+        ch.setFormatter(logging.Formatter("[%(asctime)s] %(levelname)s: %(message)s", "%H:%M:%S"))
+        self.logger.addHandler(ch)
+
+        fh = RotatingFileHandler(self.text_log_path, maxBytes=5_000_000, backupCount=3, encoding="utf-8")
+        fh.setLevel(logging.DEBUG)
+        fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s [%(name)s]: %(message)s", "%Y-%m-%d %H:%M:%S"))
+        self.logger.addHandler(fh)
+
+        # JSONL stream
+        self._jsonl = open(self.jsonl_path, "a", encoding="utf-8")
+
+        # Environment capture
+        self.ctx = RunContext.capture()
+        self.log_event("run_start", {"context": self.ctx.__dict__, "run_name": run_name})
+
+        # Optional MLflow
+        self.mlflow_run = None
+        if mlflow_enable and mlflow is not None:
+            if mlflow_experiment:
+                mlflow.set_experiment(mlflow_experiment)
+            self.mlflow_run = mlflow.start_run(run_name=run_name)
+            self.logger.info("MLflow run started.")
+
+    def log_event(self, event: str, payload: Dict[str, Any]) -> None:
+        rec = {"event": event, **payload}
+        self._jsonl.write(json.dumps(rec, ensure_ascii=False) + "\n")
+        self._jsonl.flush()
+
+    def log_params(self, params: Dict[str, Any]) -> None:
+        self.log_event("params", {"params": params})
+        if self.mlflow_run is not None and mlflow is not None:
+            flat = flatten_dict(params)
+            mlflow.log_params(flat)
+
+    def log_metrics(self, metrics: Dict[str, float], step: Optional[int] = None, split: str = "train") -> None:
+        payload = {"metrics": metrics, "step": step, "split": split}
+        self.log_event("metrics", payload)
+        if self.mlflow_run is not None and mlflow is not None:
+            mlflow.log_metrics(prefix_keys(metrics, f"{split}/"), step=step)
+
+    def info(self, msg: str) -> None:
+        self.logger.info(msg)
+
+    def warning(self, msg: str) -> None:
+        self.logger.warning(msg)
+
+    def error(self, msg: str) -> None:
+        self.logger.error(msg)
+
+    def artifact(self, path: str, name: Optional[str] = None) -> None:
+        """
+        Register an artifact path; if MLflow enabled, log it there also.
+        """
+        self.log_event("artifact", {"path": path, "name": name})
+        if self.mlflow_run is not None and mlflow is not None:
+            mlflow.log_artifact(path, artifact_path=name)
+
+    def close(self) -> None:
+        self.log_event("run_end", {"run_name": self.run_name})
+        try:
+            self._jsonl.flush()
+            self._jsonl.close()
+        except Exception:
+            pass
+        if self.mlflow_run is not None and mlflow is not None:
+            mlflow.end_run()
+            self.logger.info("MLflow run closed.")
+
+
+def flatten_dict(d: Dict[str, Any], parent_key: str = "", sep: str = ".") -> Dict[str, Any]:
+    out: Dict[str, Any] = {}
+    for k, v in d.items():
+        key = f"{parent_key}{sep}{k}" if parent_key else k
+        if isinstance(v, dict):
+            out.update(flatten_dict(v, key, sep))
+        else:
+            out[key] = v
+    return out
+
+def prefix_keys(d: Dict[str, float], prefix: str) -> Dict[str, float]:
+    return {f"{prefix}{k}": v for k, v in d.items()}

--- a/src/spectramind/train/losses.py
+++ b/src/spectramind/train/losses.py
@@ -1,137 +1,84 @@
-from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Optional
 
-import math
-from typing import Dict, Optional, Tuple
-
-import numpy as np
-
-try:
-    import torch
-    import torch.nn.functional as F
-except Exception:  # pragma: no cover
-    torch = None  # type: ignore
-    F = None  # type: ignore
+import torch
+import torch.nn.functional as F
 
 
-def gaussian_log_likelihood(mu, sigma, target, eps: float = 1e-6):
-    """Compute per-sample Gaussian Log-Likelihood (negative log prob).
-
-    Returns
-    -------
-    loss : tensor
-        Mean NLL over batch and dimensions.
+@dataclass
+class GaussianLikelihoodLoss:
     """
-    if torch is None:
-        # Fallback: numpy-based approximation for environments without torch
-        sigma_safe = np.clip(sigma, eps, None)
-        nll = 0.5 * (
-            np.log(2 * math.pi)
-            + 2 * np.log(sigma_safe)
-            + ((target - mu) ** 2) / (sigma_safe**2)
-        )
-        return float(np.mean(nll))
-
-    sigma = torch.clamp(sigma, min=eps)
-    nll = 0.5 * (
-        math.log(2 * math.pi)
-        + 2.0 * torch.log(sigma)
-        + ((target - mu) ** 2) / (sigma**2)
-    )
-    return nll.mean()
-
-
-def l2_smoothness(x, weight: float = 1.0):
-    """Penalize second finite difference along the last dimension (spectral smoothness)."""
-    if torch is None:
-        d2 = np.diff(x, n=2, axis=-1)
-        return float(weight) * float(np.mean(d2**2))
-    d2 = x[..., 2:] - 2 * x[..., 1:-1] + x[..., :-2]
-    return weight * (d2**2).mean()
-
-
-def fft_power_penalty(x, weight: float = 1.0, hi_freq_cut: Optional[int] = None):
-    """Penalize high-frequency FFT power beyond ``hi_freq_cut``.
-
-    Assumes last dimension is spectral/time.
+    Negative log-likelihood for (mu, sigma) outputs vs. target y.
+    Assumes sigma is a positive scale (we apply softplus if needed).
     """
-    if torch is None:
-        X = np.fft.rfft(x, axis=-1)
-        if hi_freq_cut is not None:
-            X[..., :hi_freq_cut] = 0
-        return float(weight) * float(np.mean(np.abs(X) ** 2))
-    X = torch.fft.rfft(x, dim=-1)
-    if hi_freq_cut is not None:
-        X = X[..., hi_freq_cut:]
-    return weight * (X.abs() ** 2).mean()
+    min_sigma: float = 1e-3
+    clamp_sigma: Optional[float] = None  # If provided, clamp sigma <= this value
+
+    def __call__(self, mu: torch.Tensor, sigma: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        sigma = F.softplus(sigma) + self.min_sigma
+        if self.clamp_sigma is not None:
+            sigma = torch.clamp(sigma, max=self.clamp_sigma)
+
+        # Gaussian NLL up to a constant: 0.5 * [ ((y-mu)/sigma)^2 + 2*log(sigma) ]
+        z = (y - mu) / sigma
+        return 0.5 * (z ** 2 + 2.0 * torch.log(sigma)).mean()
 
 
-def symbolic_constraints(mu, cfg: Dict) -> Tuple[Optional["torch.Tensor"], Dict[str, float]]:
-    """Hook for symbolic/physics-informed constraints. Non-fatal if unavailable.
-
-    This function looks for a callable specified in cfg like::
-
-        cfg.symbolic = {"callable": "spectramind.symbolic.symbolic_loss:compute", "weight": 0.1}
-
-    It dynamically imports and runs the symbolic loss if available. Returns:
-        (loss_tensor_or_None, metrics_dict)
+@dataclass
+class SmoothnessLoss:
     """
-    weight = float(cfg.get("weight", 0.0)) if cfg else 0.0
-    if weight <= 0:
-        return None, {}
+    L2 smoothness penalty on adjacent bin differences (for spectral smoothness).
+    """
+    weight: float = 1.0
+    dim: int = -1  # dimension along which bins lie
 
-    target = None
-    try:
-        path = cfg.get("callable", "")
-        if not path or ":" not in path:
-            return None, {}
-        mod_name, func_name = path.split(":", 1)
-        mod = __import__(mod_name, fromlist=[func_name])
-        func = getattr(mod, func_name)
-        loss_tensor, info = func(mu=mu, cfg=cfg)  # type: ignore
-        if loss_tensor is None:
-            return None, {}
-        if torch is None:
-            return None, info or {}
-        return weight * loss_tensor, info or {}
-    except Exception:
-        return None, {}
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        diffs = x.diff(dim=self.dim)
+        return self.weight * (diffs ** 2).mean()
 
 
-def assemble_losses(mu, sigma, target, cfg: Dict) -> Tuple["torch.Tensor" | float, Dict[str, float]]:
-    """Compose all losses based on cfg dict."""
-    metrics: Dict[str, float] = {}
+@dataclass
+class AsymmetryLoss:
+    """
+    Penalize asymmetry across a midpoint (useful for physics-informed priors in some contexts).
+    """
+    weight: float = 1.0
+    dim: int = -1
 
-    # Gaussian Log-Likelihood
-    gll_w = float(cfg.get("gll", {}).get("weight", 1.0))
-    gll = gaussian_log_likelihood(mu, sigma, target)
-    total = gll_w * gll
-    metrics["loss_gll"] = float(gll if isinstance(gll, (float, int)) else gll.item())
-    metrics["w_gll"] = gll_w
+    def __call__(self, x: torch.Tensor) -> torch.Tensor:
+        n = x.size(self.dim)
+        left = x.narrow(dim=self.dim, start=0, length=n // 2)
+        right = x.narrow(dim=self.dim, start=n - left.size(self.dim), length=left.size(self.dim)).flip(self.dim)
+        return self.weight * F.l1_loss(left, right)
 
-    # Smoothness
-    sm_w = float(cfg.get("smooth", {}).get("weight", 0.0))
-    if sm_w > 0:
-        sm = l2_smoothness(mu, weight=sm_w)
-        total = total + sm
-        metrics["loss_smooth"] = float(sm if isinstance(sm, (float, int)) else sm.item())
-        metrics["w_smooth"] = sm_w
 
-    # FFT
-    fft_cfg = cfg.get("fft", {})
-    fft_w = float(fft_cfg.get("weight", 0.0))
-    if fft_w > 0:
-        cutoff = fft_cfg.get("hi_freq_cut", None)
-        fp = fft_power_penalty(mu, weight=fft_w, hi_freq_cut=cutoff)
-        total = total + fp
-        metrics["loss_fft"] = float(fp if isinstance(fp, (float, int)) else fp.item())
-        metrics["w_fft"] = fft_w
+class CompositeLoss(torch.nn.Module):
+    """
+    Composite loss wrapper merging a main loss (e.g., GLL) with optional auxiliary penalties.
+    """
+    def __init__(self, main_loss: GaussianLikelihoodLoss, smooth: Optional[SmoothnessLoss] = None, asym: Optional[AsymmetryLoss] = None, lambda_smooth: float = 0.0, lambda_asym: float = 0.0) -> None:
+        super().__init__()
+        self.main_loss = main_loss
+        self.smooth = smooth
+        self.asym = asym
+        self.lambda_smooth = lambda_smooth
+        self.lambda_asym = lambda_asym
 
-    # Symbolic
-    sym_loss, sym_info = symbolic_constraints(mu, cfg.get("symbolic", {}))
-    if sym_loss is not None:
-        total = total + sym_loss
-        for k, v in (sym_info or {}).items():
-            metrics[f"sym_{k}"] = float(v)
+    def forward(self, mu: torch.Tensor, sigma: torch.Tensor, y: torch.Tensor) -> Dict[str, torch.Tensor]:
+        losses: Dict[str, torch.Tensor] = {}
+        gll = self.main_loss(mu, sigma, y)
+        losses["gll"] = gll
+        total = gll
 
-    return total, metrics
+        if self.smooth is not None:
+            ls = self.smooth(mu)
+            losses["smooth"] = ls
+            total = total + self.lambda_smooth * ls
 
+        if self.asym is not None:
+            la = self.asym(mu)
+            losses["asym"] = la
+            total = total + self.lambda_asym * la
+
+        losses["total"] = total
+        return losses

--- a/src/spectramind/train/optim.py
+++ b/src/spectramind/train/optim.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict, Optional
+import math
+import torch
+
+def build_optimizer(model: torch.nn.Module, cfg: Dict[str, Any]) -> torch.optim.Optimizer:
+    """
+    Build optimizer from config dict:
+    cfg example:
+    {
+        "name": "adamw",
+        "lr": 3e-4,
+        "weight_decay": 0.01,
+        "betas": [0.9, 0.999],
+        "eps": 1e-8
+    }
+    """
+    name = (cfg.get("name") or "adamw").lower()
+    lr = float(cfg.get("lr", 3e-4))
+    wd = float(cfg.get("weight_decay", 0.0))
+    params = [p for p in model.parameters() if p.requires_grad]
+
+    if name == "adamw":
+        betas = tuple(cfg.get("betas", (0.9, 0.999)))  # type: ignore
+        eps = float(cfg.get("eps", 1e-8))
+        return torch.optim.AdamW(params, lr=lr, weight_decay=wd, betas=betas, eps=eps)
+    if name == "adam":
+        betas = tuple(cfg.get("betas", (0.9, 0.999)))  # type: ignore
+        eps = float(cfg.get("eps", 1e-8))
+        return torch.optim.Adam(params, lr=lr, weight_decay=wd, betas=betas, eps=eps)
+    if name == "sgd":
+        momentum = float(cfg.get("momentum", 0.9))
+        nesterov = bool(cfg.get("nesterov", True))
+        return torch.optim.SGD(params, lr=lr, momentum=momentum, weight_decay=wd, nesterov=nesterov)
+    raise ValueError(f"Unknown optimizer: {name}")
+
+
+def build_scheduler(optimizer: torch.optim.Optimizer, cfg: Optional[Dict[str, Any]], total_steps: Optional[int] = None):
+    """
+    Build LR scheduler from config. Supported:
+    - cosine: CosineAnnealingLR (requires T_max)
+    - cosine_warmup: linear warmup to base LR then cosine decay over total_steps
+    - onecycle: OneCycleLR (requires total_steps)
+    - step: StepLR (step_size, gamma)
+
+    Returns scheduler or None.
+    """
+    if not cfg:
+        return None
+    name = (cfg.get("name") or "none").lower()
+
+    if name == "cosine":
+        tmax = int(cfg.get("t_max", total_steps or 1000))
+        return torch.optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=tmax)
+    if name == "cosine_warmup":
+        if total_steps is None:
+            raise ValueError("cosine_warmup requires total_steps")
+        warmup_steps = int(cfg.get("warmup_steps", max(1, int(0.05 * total_steps))))
+        def lr_lambda(step):
+            if step < warmup_steps:
+                return (step + 1) / warmup_steps
+            progress = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+            return 0.5 * (1 + math.cos(math.pi * progress))
+        return torch.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=lr_lambda)
+    if name == "onecycle":
+        if total_steps is None:
+            raise ValueError("onecycle requires total_steps")
+        max_lr = float(cfg.get("max_lr", 1e-3))
+        pct_start = float(cfg.get("pct_start", 0.3))
+        return torch.optim.lr_scheduler.OneCycleLR(optimizer, max_lr=max_lr, total_steps=total_steps, pct_start=pct_start)
+    if name == "step":
+        step_size = int(cfg.get("step_size", 1000))
+        gamma = float(cfg.get("gamma", 0.1))
+        return torch.optim.lr_scheduler.StepLR(optimizer, step_size=step_size, gamma=gamma)
+    if name in ("none", "null"):
+        return None
+    raise ValueError(f"Unknown scheduler: {name}")

--- a/src/spectramind/train/registry.py
+++ b/src/spectramind/train/registry.py
@@ -1,0 +1,27 @@
+import importlib
+from typing import Any, Dict
+
+def resolve_callable(target: str):
+    """
+    Resolve a dotted 'module:callable' or 'module.sub:callable' path to an object.
+    """
+    if ":" in target:
+        module_name, attr = target.split(":")
+    else:
+        # Support "module.attr" form as well
+        parts = target.split(".")
+        module_name, attr = ".".join(parts[:-1]), parts[-1]
+    mod = importlib.import_module(module_name)
+    return getattr(mod, attr)
+
+def build_from_target(cfg: Dict[str, Any]) -> Any:
+    """
+    Instantiate a class or call a function given:
+    cfg = {"target": "package.module:ClassName", "params": {...}}
+    """
+    target = cfg.get("target")
+    if not target:
+        raise ValueError("Missing 'target' in config block.")
+    ctor = resolve_callable(target)
+    params = cfg.get("params") or {}
+    return ctor(**params)

--- a/src/spectramind/train/selftest.py
+++ b/src/spectramind/train/selftest.py
@@ -1,0 +1,37 @@
+"""
+Self-test for src/spectramind/train
+
+Runs a tiny CPU-only smoke training using the built-in dummy dataset/model in train_v50
+to verify:
+
+* Logging (console + rotating file + JSONL)
+* Optimizer/scheduler wiring
+* AMP disabled path
+* Checkpoint writes ('last.ckpt' and 'best.ckpt')
+* Early stopping path
+"""
+import os
+from pathlib import Path
+
+from .train_v50 import run_train
+
+
+def main():
+    out_dir = "runs/selftest-train"
+    cfg = {
+        "run": {"name": "train-selftest", "out_dir": out_dir, "seed": 7, "device": "cpu", "mlflow": False},
+        "dummy_mode": True,
+        "dummy": {"dummy_dims": 32, "dummy_bins": 16},
+        "loss": {"main": {"target": "spectramind.train.losses:GaussianLikelihoodLoss", "params": {"min_sigma": 1e-3}}},
+        "optim": {"name": "adamw", "lr": 1e-3, "weight_decay": 0.0},
+        "sched": {"name": "cosine_warmup", "warmup_steps": 10},
+        "train": {"epochs": 4, "grad_accum": 1, "amp": False, "clip_grad_norm": 1.0, "patience": 2},
+    }
+    summary = run_train(cfg)
+    assert (Path(out_dir) / "last.ckpt").exists(), "last.ckpt not found"
+    assert "best_val_loss" in summary, "Summary missing best_val_loss"
+    print("Self-test OK:", summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/spectramind/train/step_processors.py
+++ b/src/spectramind/train/step_processors.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Dict, Tuple
+
+import torch
+
+
+@dataclass
+class GenericGaussianProcessor:
+    """
+    Generic step processor assuming the model returns a dict with 'mu' and 'sigma'
+    (or a tuple (mu, sigma)), and batch provides inputs 'x' and target 'y'.
+
+    This class abstracts the per-batch training/validation step logic used by TrainerBase.
+    """
+    loss_module: torch.nn.Module  # Expected to return a dict with {'total': ..., ...}
+
+    def __call__(self, model: torch.nn.Module, batch: Dict[str, torch.Tensor], device: torch.device) -> Tuple[torch.Tensor, Dict[str, float]]:
+        x = batch["x"].to(device)
+        y = batch["y"].to(device)
+
+        out = model(x)
+        if isinstance(out, (tuple, list)) and len(out) >= 2:
+            mu, sigma = out[0], out[1]
+        elif isinstance(out, dict) and "mu" in out and "sigma" in out:
+            mu, sigma = out["mu"], out["sigma"]
+        else:
+            raise ValueError("Model output must be (mu, sigma) tuple or dict with keys 'mu' and 'sigma'.")
+
+        losses = self.loss_module(mu, sigma, y)
+        total = losses["total"]
+        scalars = {k: float(v.detach().item()) for k, v in losses.items()}
+        return total, scalars

--- a/src/spectramind/train/train_mae_v50.py
+++ b/src/spectramind/train/train_mae_v50.py
@@ -1,246 +1,129 @@
-from __future__ import annotations
-
 """
-SpectraMind V50 — Masked Autoencoder (MAE) Pretraining
+Masked Autoencoder (MAE) pretraining runner for SpectraMind V50.
 
-This module implements MAE-style pretraining for spectral/time cubes with support for:
+Notes:
 
-* Random/block/molecule-region masking (delegated to dataset via cfg)
-* AMP mixed precision
-* Cosine LR with warmup
-* Logging to JSONL and MLflow (optional)
-* Checkpointing + Early stopping on reconstruction loss
+* Expects a dataset class that yields (inputs, mask_targets, mask) as needed by the chosen MAE.
+* This module focuses on orchestration: logging, seeding, optimizer/scheduler, AMP, checkpoints.
+* For the V50 project, recommended dataset: ArielMAEDatasetV50 (configured via Hydra).
+  """
+from typing import Any, Dict, Optional
+import math
+import os
 
-Expected cfg sections:
-mae:
-  mask_ratio: 0.75
-  loss: "l2"          # or "l1"
-trainer: {...}        # same schema as supervised trainer where sensible
-model:
-  module: "spectramind.models.v50_mae:build"
-data:
-  module: "spectramind.data.ariel_mae_dataset_v50:build"
-optimizer: {...}
-scheduler: {...}
-"""
+import torch
+from torch.utils.data import DataLoader, Dataset
 
-from typing import Any, Dict, Tuple
-
-from .callbacks import Checkpointer, EarlyStopper
-from .common import capture_run_meta, get_device, set_seed, write_debug_log
-from .data_loading import build_dataloaders
-from .logger import (
-    get_logger,
-    try_mlflow_end,
-    try_mlflow_log_metrics,
-    try_mlflow_log_params,
-    try_mlflow_start,
-    write_jsonl,
-)
-from .schedulers import cosine_with_warmup
-
-import importlib
-
-try:
-    import torch
-    import torch.nn as nn
-    import torch.nn.functional as F
-except Exception:  # pragma: no cover
-    torch = None  # type: ignore
-    nn = None  # type: ignore
-    F = None  # type: ignore
-
-try:
-    import hydra  # type: ignore
-    from omegaconf import OmegaConf  # type: ignore
-except Exception:  # pragma: no cover
-    hydra = None
-    OmegaConf = None  # type: ignore
+from .callbacks import CheckpointManager, EarlyStopping
+from .experiment_logger import ExperimentLogger
+from .optim import build_optimizer, build_scheduler
+from .registry import build_from_target, resolve_callable
+from .trainer_base import TrainerBase
+from .utils import dump_yaml_safely, ensure_dir, get_device, seed_everything
 
 
-def _build_model(cfg: Dict[str, Any]) -> "torch.nn.Module":
-    mod_name, fn_name = cfg["model"]["module"].split(":")
-    mod = importlib.import_module(mod_name)
-    return getattr(mod, fn_name)(cfg)  # type: ignore
-
-
-def _recon_loss(pred, target, typ: str = "l2"):
-    if typ == "l1":
-        return (pred - target).abs().mean()
-    return ((pred - target) ** 2).mean()
-
-
-def _forward_mae(model, batch):
+class _MAEProcessor:
     """
-    Expect dataset to provide:
-    batch["x"]: input tensor
-    batch["mask"]: boolean mask of missing/hidden patches/bins
-    model(x, mask) -> reconstruction over masked regions (or full with mask)
-    batch["target"]: ground truth for reconstruction (same shape as model output)
+    Generic MAE batch processor.
+
+    Expected model signatures:
+      out = model(x, mask=mask) -> dict with 'loss' and optional sub-losses (e.g., 'recon')
+    or
+      loss = model.compute_loss(x, mask=mask, target=target)
+
+    This processor standardizes to return (loss_tensor, scalar_metrics).
     """
-    x = batch["x"]
-    mask = batch.get("mask", None)
-    target = batch.get("target", x)
-    if mask is None:
-        out = model(x)
-    else:
-        out = model(x, mask=mask)
-    return out, target
+    def __call__(self, model: torch.nn.Module, batch: Dict, device: torch.device):
+        x = batch["x"].to(device)
+        mask = batch.get("mask")
+        if mask is not None:
+            mask = mask.to(device)
+        target = batch.get("target")
+        if target is not None:
+            target = target.to(device)
+
+        if hasattr(model, "compute_loss"):
+            loss = model.compute_loss(x, mask=mask, target=target)
+            scalars = {"mae": float(loss.detach().item())}
+            return loss, scalars
+
+        out = model(x, mask=mask, target=target) if "target" in batch else model(x, mask=mask)
+        if isinstance(out, dict) and "loss" in out:
+            loss = out["loss"]
+            scalars = {k: float(v.detach().item()) for k, v in out.items() if hasattr(v, "detach")}
+            return loss, scalars
+
+        raise ValueError("MAE model must implement either 'compute_loss' or return dict with 'loss'.")
 
 
-def run_mae_pretraining(cfg: Dict[str, Any]) -> Dict[str, Any]:
-    logger = get_logger()
-    set_seed(int(cfg.get("seed", 42)))
-    meta = capture_run_meta(
-        cfg, cli_version=str(cfg.get("cli_version", "v50")), seed=int(cfg.get("seed", 42))
+def run_train(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    run = cfg.get("run", {})
+    out_dir = run.get("out_dir", "runs/mae")
+    run_name = run.get("name", "v50-mae")
+    seed = int(run.get("seed", 1337))
+    device_pref = run.get("device", "cuda")
+
+    ensure_dir(out_dir)
+    seed_everything(seed)
+    logger = ExperimentLogger(run_name=run_name, log_dir=out_dir, mlflow_enable=bool(run.get("mlflow", False)), mlflow_experiment=run.get("mlflow_experiment"))
+    logger.log_params({"cfg": cfg})
+
+    device = get_device(device_pref)
+    logger.info(f"Using device: {device}")
+
+    # Data
+    data_cfg = cfg.get("data", {})
+    train_ds = build_from_target(data_cfg["train"])
+    val_ds = build_from_target(data_cfg["val"]) if "val" in data_cfg and data_cfg["val"] else None
+    loader_cfg = data_cfg.get("loader", {"batch_size": 16, "num_workers": 0, "pin_memory": False})
+    train_loader = DataLoader(train_ds, batch_size=int(loader_cfg.get("batch_size", 16)), shuffle=True, num_workers=int(loader_cfg.get("num_workers", 0)), pin_memory=bool(loader_cfg.get("pin_memory", False)), drop_last=True)
+    val_loader = DataLoader(val_ds, batch_size=int(loader_cfg.get("batch_size", 16)), shuffle=False, num_workers=int(loader_cfg.get("num_workers", 0)), pin_memory=bool(loader_cfg.get("pin_memory", False)), drop_last=False) if val_ds is not None else None
+
+    # Model
+    model_cfg = cfg.get("model")
+    if not model_cfg:
+        raise ValueError("Missing 'model' block for MAE training.")
+    model = build_from_target(model_cfg)
+
+    # Optim & Sched
+    optim_cfg = cfg.get("optim", {"name": "adamw", "lr": 1e-3, "weight_decay": 0.01})
+    optimizer = build_optimizer(model, optim_cfg)
+    total_steps = int(cfg.get("train", {}).get("epochs", 10)) * max(1, len(train_loader))
+    scheduler = build_scheduler(optimizer, cfg.get("sched"), total_steps=total_steps)
+
+    # Trainer
+    ckpt = CheckpointManager(out_dir)
+    early = EarlyStopping(monitor="val_loss", mode="min", patience=int(cfg.get("train", {}).get("patience", 5)))
+    trainer = TrainerBase(
+        model=model,
+        optimizer=optimizer,
+        scheduler=scheduler,
+        step_fn=_MAEProcessor(),
+        device=device,
+        logger=logger,
+        grad_accum_steps=int(cfg.get("train", {}).get("grad_accum", 1)),
+        use_amp=bool(cfg.get("train", {}).get("amp", True)),
+        clip_grad_norm=float(cfg.get("train", {}).get("clip_grad_norm", 1.0)),
+        checkpoint=ckpt,
+        early_stopping=early if val_loader is not None else None,
     )
-    write_debug_log(meta)
-    try_mlflow_start(
-        run_name=f"mae_v50_{meta.config_hash}",
-        tags={"cfg": meta.config_hash, "ver": meta.cli_version},
+
+    dump_yaml_safely(cfg, os.path.join(out_dir, "config_snapshot.yaml"))
+
+    # Fit
+    summary = trainer.fit(
+        train_loader=train_loader,
+        val_loader=val_loader,
+        epochs=int(cfg.get("train", {}).get("epochs", 10)),
+        start_epoch=1,
     )
-    try_mlflow_log_params({"cfg_hash": meta.config_hash, "cli_version": meta.cli_version})
-
-    if torch is None:
-        raise RuntimeError("PyTorch is required for MAE pretraining.")
-
-    device, _ = get_device("cuda")
-
-    dls = build_dataloaders(cfg)
-    train_loader, val_loader = dls.train, dls.val
-
-    model = _build_model(cfg).to(device)
-
-    optimizer = torch.optim.AdamW(
-        model.parameters(),
-        lr=float(cfg["optimizer"].get("lr", 3e-4)),
-        weight_decay=float(cfg["optimizer"].get("wd", 1e-4)),
-    )
-    scheduler = cosine_with_warmup(
-        optimizer,
-        warmup_steps=int(cfg["scheduler"].get("warmup_steps", 500)),
-        total_steps=int(cfg["scheduler"].get("total_steps", 10000)),
-    )
-
-    ckpt_dir = cfg["trainer"].get("ckpt_dir", "artifacts/mae_checkpoints")
-    checkpointer = Checkpointer(
-        ckpt_dir, keep_last=int(cfg["trainer"].get("keep_last", 5))
-    )
-    early = EarlyStopper(
-        patience=int(cfg["trainer"]["early_stop"].get("patience", 10)),
-        min_delta=float(cfg["trainer"]["early_stop"].get("min_delta", 0.0)),
-        metric_name="val_loss",
-    )
-
-    amp = bool(cfg["trainer"].get("amp", True))
-    scaler = torch.cuda.amp.GradScaler(enabled=amp)
-    loss_typ = str(cfg["mae"].get("loss", "l2"))
-    accum = int(cfg["trainer"].get("grad_accum", 1))
-    log_every = int(cfg["trainer"].get("log_every", 50))
-
-    global_step = 0
-    best = None
-    for epoch in range(1, int(cfg["trainer"]["max_epochs"]) + 1):
-        model.train()
-        running: Dict[str, float] = {}
-        for it, batch in enumerate(train_loader, start=1):
-            for k, v in (batch.items() if isinstance(batch, dict) else []):
-                if torch.is_tensor(v):
-                    batch[k] = v.to(device, non_blocking=True)
-            with torch.autocast(
-                device_type="cuda" if torch.cuda.is_available() else "cpu",
-                dtype=torch.float16,
-                enabled=amp,
-            ):
-                pred, tgt = _forward_mae(model, batch)
-                loss = _recon_loss(pred, tgt, typ=loss_typ) / accum
-            scaler.scale(loss).backward()
-            if it % accum == 0:
-                scaler.step(optimizer)
-                scaler.update()
-                optimizer.zero_grad(set_to_none=True)
-                if scheduler is not None:
-                    scheduler.step()
-                global_step += 1
-                running["loss"] = running.get("loss", 0.0) + float(loss.item() * accum)
-                if global_step % log_every == 0:
-                    avg = {k: v / log_every for k, v in running.items()}
-                    write_jsonl({"event": "mae_train_step", "step": global_step, **avg})
-                    try_mlflow_log_metrics(avg, step=global_step)
-                    running = {}
-
-        # Validation
-        model.eval()
-        vals = []
-        with torch.no_grad():
-            for batch in val_loader:
-                for k, v in (batch.items() if isinstance(batch, dict) else []):
-                    if torch.is_tensor(v):
-                        batch[k] = v.to(device, non_blocking=True)
-                pred, tgt = _forward_mae(model, batch)
-                v = _recon_loss(pred, tgt, typ=loss_typ)
-                vals.append(float(v.item()))
-        vmean = float(sum(vals) / max(1, len(vals)))
-        write_jsonl({"event": "mae_val_epoch", "epoch": epoch, "val_loss": vmean})
-        try_mlflow_log_metrics({"val_loss": vmean}, step=epoch)
-
-        # Checkpointing
-        checkpointer.save_periodic(
-            {
-                "epoch": epoch,
-                "model": model.state_dict(),
-                "optimizer": optimizer.state_dict(),
-                "scheduler": (
-                    None if scheduler is None else scheduler.state_dict()
-                ),
-                "cfg": cfg,
-            },
-            tag=f"epoch_{epoch:03d}",
-        )
-        maybe = checkpointer.try_save_best(
-            {
-                "epoch": epoch,
-                "model": model.state_dict(),
-                "optimizer": optimizer.state_dict(),
-                "scheduler": (
-                    None if scheduler is None else scheduler.state_dict()
-                ),
-                "cfg": cfg,
-            },
-            value=vmean,
-        )
-        if maybe:
-            best = maybe
-
-        if early.step(vmean):
-            get_logger().info(
-                f"Early stopping at epoch {epoch} (best {early.best:.6f})."
-            )
-            break
-
-    try_mlflow_end()
-    from .common import export_manifest
-
-    manifest = {
-        "best_checkpoint": best,
-        "events_jsonl": "train_events.jsonl",
-        "log_file": "logs/train.log",
-        "cfg_hash": meta.config_hash,
-    }
-    export_manifest(manifest, out_path="artifacts/mae_manifest.json")
-    return manifest
+    logger.info(f"MAE training completed. Best val loss: {summary['best_val_loss']:.6f}")
+    logger.close()
+    return summary
 
 
-if hydra is not None:
-
-    @hydra.main(config_path=None, config_name=None, version_base=None)
-    def _main(cfg):  # type: ignore
-        cfg_dict = OmegaConf.to_container(cfg, resolve=True)  # type: ignore
-        run_mae_pretraining(cfg_dict)  # type: ignore
-
-
-if __name__ == "__main__":  # pragma: no cover
-    if hydra is None:
-        raise SystemExit("Hydra is required to run this module as a script.")
-    _main()  # type: ignore
-
+if __name__ == "__main__":
+    # smoke-test stub requires a real dataset/model configured via cfg
+    import sys
+    print("Run this via the SpectraMind CLI or by calling run_train(cfg) with a proper MAE dataset+model.")
+    sys.exit(0)

--- a/src/spectramind/train/train_v50.py
+++ b/src/spectramind/train/train_v50.py
@@ -1,389 +1,265 @@
-from __future__ import annotations
-
 """
-SpectraMind V50 — Supervised Training (μ/σ) with Physics/Symbolic Losses
+train_v50.py
+=============
 
-Hydra config expectations (example):
-trainer:
-  max_epochs: 50
-  grad_accum: 1
-  amp: true
-  clip_grad: 1.0
-  log_every: 50
-  ckpt_dir: "artifacts/checkpoints"
-  save_every_epochs: 1
-  early_stop:
-    patience: 7
-    min_delta: 0.0
-model:
-  module: "spectramind.models.v50_model:build"
-optimizer:
-  lr: 3e-4
-  wd: 1e-4
-  betas: [0.9, 0.999]
-scheduler:
-  type: "cosine"
-  warmup_steps: 500
-  total_steps: 10000
-loss:
-  gll: { weight: 1.0 }
-  smooth: { weight: 0.01 }
-  fft: { weight: 0.0, hi_freq_cut: null }
-  symbolic: { weight: 0.0, callable: "" }
-data:
-  module: "spectramind.data.ariel_dataset:build"
-  batch_size: 16
-  num_workers: 4
-  pin_memory: true
-seed: 42
+General supervised training entry point for SpectraMind V50.
+
+Design:
+
+* Hydra/OmegaConf friendly (but does not hard-depend on Hydra to remain runnable)
+* Uses registry-style builders for datasets, model, loss, optimizer, scheduler, and step processor
+* Mission-grade logging via ExperimentLogger (console + rotating file + JSONL + optional MLflow)
+* Deterministic seeding, AMP, grad accumulation, checkpointing, early stopping
+
+Example (with OmegaConf YAML):
+cfg:
+  run:
+    name: "v50-trial"
+    out_dir: "runs/v50-trial"
+    seed: 1337
+    device: "cuda"
+    mlflow: false
+    mlflow_experiment: null
+  data:
+    train:
+      target: "your_pkg.data:YourTrainDataset"
+      params: { ... }
+    val:
+      target: "your_pkg.data:YourValDataset"
+      params: { ... }
+    loader:
+      batch_size: 16
+      num_workers: 4
+      pin_memory: true
+  model:
+    target: "your_pkg.models:YourModel"
+    params: { ... }
+  loss:
+    main:
+      target: "spectramind.train.losses:GaussianLikelihoodLoss"
+      params: { "min_sigma": 1e-3 }
+    smooth:
+      target: "spectramind.train.losses:SmoothnessLoss"
+      params: { "weight": 0.1 }
+    asym:
+      target: "spectramind.train.losses:AsymmetryLoss"
+      params: { "weight": 0.05 }
+    weights:
+      lambda_smooth: 0.1
+      lambda_asym: 0.05
+  step_processor:
+    target: "spectramind.train.step_processors:GenericGaussianProcessor"
+    params: {}
+  optim:
+    name: "adamw"
+    lr: 0.0003
+    weight_decay: 0.01
+  sched:
+    name: "cosine_warmup"
+    warmup_steps: 500
+  train:
+    epochs: 20
+    grad_accum: 1
+    amp: true
+    clip_grad_norm: 1.0
+    patience: 8
+
+A minimal built-in dummy mode is provided for smoke testing if no model/dataset are configured.
 """
-
+import math
 import os
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional
 
-import numpy as np
+import torch
+from torch.utils.data import DataLoader, Dataset
 
-from .callbacks import Checkpointer, EarlyStopper
-from .common import capture_run_meta, get_device, set_seed, write_debug_log
-from .data_loading import build_dataloaders
-from .logger import (
-    get_logger,
-    try_mlflow_end,
-    try_mlflow_log_metrics,
-    try_mlflow_log_params,
-    try_mlflow_start,
-    write_jsonl,
-)
-from .losses import assemble_losses
-from .schedulers import cosine_with_warmup
+from .callbacks import CheckpointManager, EarlyStopping
+from .experiment_logger import ExperimentLogger
+from .losses import AsymmetryLoss, CompositeLoss, GaussianLikelihoodLoss, SmoothnessLoss
+from .optim import build_optimizer, build_scheduler
+from .registry import build_from_target
+from .step_processors import GenericGaussianProcessor
+from .trainer_base import TrainerBase, TrainerHooks
+from .utils import RunContext, dump_yaml_safely, ensure_dir, get_device, seed_everything
 
-import importlib
+# -------------------------
 
-try:
-    import torch
-    import torch.nn as nn
-except Exception:  # pragma: no cover
-    torch = None  # type: ignore
-    nn = None  # type: ignore
+# Built-in dummy components
 
-try:
-    import hydra  # type: ignore
-    from omegaconf import OmegaConf  # type: ignore
-except Exception:  # pragma: no cover
-    hydra = None
-    OmegaConf = None  # type: ignore
+# -------------------------
 
+class _DummyDataset(Dataset):
+    def __init__(self, n: int = 1024, dims: int = 64, noise: float = 0.1):
+        self.x = torch.randn(n, dims)
+        w = torch.randn(dims, 32) * 0.1
+        mu = self.x @ w
+        self.y = mu + noise * torch.randn_like(mu)
+        self.dims = dims
 
-def _build_model(cfg: Dict[str, Any]) -> "torch.nn.Module":
-    """Dynamically build the model from a registry string."""
-    mod_name, fn_name = cfg["model"]["module"].split(":")
-    mod = importlib.import_module(mod_name)
-    fn = getattr(mod, fn_name)
-    return fn(cfg)  # type: ignore
+    def __len__(self):
+        return self.x.size(0)
+
+    def __getitem__(self, idx):
+        return {"x": self.x[idx], "y": self.y[idx]}
 
 
-def _build_optimizer(model: "torch.nn.Module", cfg: Dict[str, Any]) -> "torch.optim.Optimizer":
-    """AdamW optimizer with Hydra-provided hyperparameters."""
-    opt_cfg = cfg["optimizer"]
-    return torch.optim.AdamW(
-        model.parameters(),
-        lr=float(opt_cfg.get("lr", 3e-4)),
-        weight_decay=float(opt_cfg.get("wd", 1e-4)),
-        betas=tuple(opt_cfg.get("betas", (0.9, 0.999))),
-    )
+class _DummyModel(torch.nn.Module):
+    def __init__(self, inp: int = 64, out: int = 32):
+        super().__init__()
+        self.net = torch.nn.Sequential(
+            torch.nn.Linear(inp, 128),
+            torch.nn.ReLU(),
+            torch.nn.Linear(128, 64),
+            torch.nn.ReLU(),
+        )
+        self.mu_head = torch.nn.Linear(64, out)
+        self.sigma_head = torch.nn.Linear(64, out)
+
+    def forward(self, x):
+        h = self.net(x)
+        mu = self.mu_head(h)
+        sigma = self.sigma_head(h)
+        return {"mu": mu, "sigma": sigma}
 
 
-def _forward_step(model, batch) -> Tuple["torch.Tensor", "torch.Tensor", "torch.Tensor"]:
-    """Forward pass wrapper. Expect the model to return (mu, sigma) given inputs."""
-    # Example batch contract:
-    # batch = {"x": tensor[B,...], "target": tensor[B, D]}
-    x = batch["x"]
-    target = batch["target"]
-    mu, sigma = model(x)
-    return mu, sigma, target
+def _make_dummy(cfg: Dict[str, Any]):
+    dims = int(cfg.get("dummy_dims", 64))
+    out_bins = int(cfg.get("dummy_bins", 32))
+    train_ds = _DummyDataset(n=1024, dims=dims)
+    val_ds = _DummyDataset(n=256, dims=dims)
+    model = _DummyModel(inp=dims, out=out_bins)
+    return train_ds, val_ds, model
+
+# -------------------------
+
+# Runner
+
+# -------------------------
+
+def _build_loss(cfg_loss: Dict[str, Any]) -> CompositeLoss:
+    main_cfg = cfg_loss.get("main") or {"target": "spectramind.train.losses:GaussianLikelihoodLoss", "params": {}}
+    main = build_from_target(main_cfg)
+    smooth = None
+    asym = None
+    if "smooth" in cfg_loss and cfg_loss["smooth"]:
+        smooth = build_from_target(cfg_loss["smooth"])
+    if "asym" in cfg_loss and cfg_loss["asym"]:
+        asym = build_from_target(cfg_loss["asym"])
+    weights = cfg_loss.get("weights") or {}
+    return CompositeLoss(main, smooth, asym, float(weights.get("lambda_smooth", 0.0)), float(weights.get("lambda_asym", 0.0)))
+
+def _dataloader(ds: Dataset, loader_cfg: Dict[str, Any]) -> DataLoader:
+    bs = int(loader_cfg.get("batch_size", 16))
+    nw = int(loader_cfg.get("num_workers", 0))
+    pm = bool(loader_cfg.get("pin_memory", False))
+    shuffle = bool(loader_cfg.get("shuffle", True))
+    return DataLoader(ds, batch_size=bs, shuffle=shuffle, num_workers=nw, pin_memory=pm, drop_last=True)
 
 
-def _evaluate(model, loader, cfg) -> Dict[str, float]:
-    """Eval loop on a dataloader split."""
-    model.eval()
-    metrics_accum = []
-    with torch.no_grad():
-        for batch in loader:
-            if isinstance(batch, dict):
-                for k, v in batch.items():
-                    if torch.is_tensor(v):
-                        batch[k] = (
-                            v.cuda(non_blocking=True)
-                            if next(model.parameters()).is_cuda
-                            else v
-                        )
-            mu, sigma, target = _forward_step(model, batch)
-            loss, parts = assemble_losses(mu, sigma, target, cfg["loss"])
-            val = float(loss.item() if torch.is_tensor(loss) else loss)
-            parts = {f"val_{k}": float(v) for k, v in parts.items()}
-            parts["val_loss"] = val
-            metrics_accum.append(parts)
-    # Average
-    if not metrics_accum:
-        return {"val_loss": float("nan")}
-    keys = metrics_accum[0].keys()
-    out = {k: float(np.mean([m[k] for m in metrics_accum if k in m])) for k in keys}
-    return out
+def run_train(cfg: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Execute supervised training given a Hydra/OmegaConf-like dict.
 
+    Returns: summary dict with key 'best_val_loss'.
+    """
+    # --- Run setup ---
+    run = cfg.get("run", {})
+    out_dir = run.get("out_dir", "runs/v50")
+    run_name = run.get("name", "v50-train")
+    seed = int(run.get("seed", 1337))
+    device_pref = run.get("device", "cuda")
+    mlflow_enable = bool(run.get("mlflow", False))
+    mlflow_experiment = run.get("mlflow_experiment")
 
-def _maybe_amp(cfg: Dict[str, Any]):
-    """Return a torch.cuda.amp autocast context manager if AMP enabled."""
-    if not cfg["trainer"].get("amp", True):
-        from contextlib import nullcontext
+    ensure_dir(out_dir)
+    seed_everything(seed)
 
-        return nullcontext()
-    return torch.autocast(
-        device_type="cuda" if torch.cuda.is_available() else "cpu", dtype=torch.float16
-    )
+    logger = ExperimentLogger(run_name=run_name, log_dir=out_dir, mlflow_enable=mlflow_enable, mlflow_experiment=mlflow_experiment)
+    logger.log_params({"cfg": cfg})
 
-
-def _grad_clip(model: "torch.nn.Module", max_norm: float) -> None:
-    """Clip gradients if ``max_norm`` > 0."""
-    if max_norm and max_norm > 0:
-        torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
-
-
-def _total_steps(cfg: Dict[str, Any], train_len: int) -> int:
-    """Estimate total optimizer steps for the scheduler."""
-    epochs = int(cfg["trainer"]["max_epochs"])
-    accum = int(cfg["trainer"].get("grad_accum", 1))
-    return max(1, (train_len * epochs) // accum)
-
-
-def _log_batch_metrics(step: int, metrics: Dict[str, float]) -> None:
-    """Log metrics to JSONL & MLflow."""
-    write_jsonl({"event": "train_step", "step": step, **metrics})
-    try_mlflow_log_metrics(metrics, step=step)
-
-
-def _log_val_metrics(epoch: int, metrics: Dict[str, float]) -> None:
-    """Log validation metrics."""
-    write_jsonl({"event": "val_epoch", "epoch": epoch, **metrics})
-    try_mlflow_log_metrics(metrics, step=epoch)
-
-
-def _log_params(params: Dict[str, Any]) -> None:
-    """Log run params to MLflow if present."""
-    try_mlflow_log_params(params)
-
-
-def _move_batch_to_device(batch, model):
-    """Move dict/tensor batch to same device as model's first parameter."""
-    dev = next(model.parameters()).device
-    if isinstance(batch, dict):
-        for k, v in batch.items():
-            if torch.is_tensor(v):
-                batch[k] = v.to(dev, non_blocking=True)
-    elif torch.is_tensor(batch):
-        batch = batch.to(dev, non_blocking=True)
-    return batch
-
-
-def _train_one_epoch(model, loader, optimizer, scheduler, cfg, step0: int) -> Tuple[int, Dict[str, float]]:
-    """One epoch training loop with grad accumulation and AMP."""
-    model.train()
-    accum = int(cfg["trainer"].get("grad_accum", 1))
-    clip = float(cfg["trainer"].get("clip_grad", 0.0))
-    log_every = int(cfg["trainer"].get("log_every", 50))
-    running: Dict[str, float] = {}
-    step = step0
-
-    scaler = torch.cuda.amp.GradScaler(enabled=cfg["trainer"].get("amp", True))
-
-    for it, batch in enumerate(loader, start=1):
-        batch = _move_batch_to_device(batch, model)
-        with _maybe_amp(cfg):
-            mu, sigma, target = _forward_step(model, batch)
-            loss, parts = assemble_losses(mu, sigma, target, cfg["loss"])
-            if torch.is_tensor(loss):
-                loss = loss / accum
-        if torch.is_tensor(loss):
-            scaler.scale(loss).backward()
-        else:
-            raise RuntimeError("Loss must be a torch tensor in supervised training.")
-
-        if it % accum == 0:
-            scaler.unscale_(optimizer)
-            _grad_clip(model, clip)
-            scaler.step(optimizer)
-            scaler.update()
-            optimizer.zero_grad(set_to_none=True)
-            if scheduler is not None:
-                scheduler.step()
-            # Aggregate + log
-            for k, v in parts.items():
-                running[k] = running.get(k, 0.0) + float(v)
-            running["loss"] = running.get("loss", 0.0) + float(loss.item() * accum)
-            step += 1
-            if step % log_every == 0:
-                avg = {k: v / log_every for k, v in running.items()}
-                _log_batch_metrics(step, avg)
-                running = {}
-    # Return last step and last running (averaged if we ended mid-window)
-    if running:
-        denom = max(1, log_every)
-        avg = {k: v / denom for k, v in running.items()}
-    else:
-        avg = {}
-    return step, avg
-
-
-def _build_scheduler(opt, cfg, train_len: int):
-    """Construct scheduler per cfg.scheduler.type."""
-    sch_cfg = cfg.get("scheduler", {}) or {}
-    typ = (sch_cfg.get("type") or "").lower()
-    if typ == "cosine":
-        total = int(sch_cfg.get("total_steps", _total_steps(cfg, train_len)))
-        warm = int(sch_cfg.get("warmup_steps", max(1, total // 20)))
-        return cosine_with_warmup(opt, warmup_steps=warm, total_steps=total)
-    elif typ == "none":
-        return None
-    else:
-        return None
-
-
-def _ensure_cuda_graph_compat(model):
-    """Optional future: prepare CUDA graph capture. Currently noop for portability."""
-    return
-
-
-def run_training(cfg: Dict[str, Any]) -> Dict[str, Any]:
-    """Orchestrate the full supervised training run and return an artifact manifest."""
-    logger = get_logger()
-    set_seed(int(cfg.get("seed", 42)))
-    meta = capture_run_meta(
-        cfg, cli_version=str(cfg.get("cli_version", "v50")), seed=int(cfg.get("seed", 42))
-    )
-    write_debug_log(meta)
-    try_mlflow_start(
-        run_name=f"train_v50_{meta.config_hash}",
-        tags={"cfg": meta.config_hash, "ver": meta.cli_version},
-    )
-    _log_params({"cfg_hash": meta.config_hash, "cli_version": meta.cli_version})
-
-    # Device
-    device, _ = get_device("cuda")
+    device = get_device(device_pref)
     logger.info(f"Using device: {device}")
 
-    # Data
-    dls = build_dataloaders(cfg)
-    train_loader, val_loader = dls.train, dls.val
+    # --- Data & Model ---
+    if cfg.get("dummy_mode", False):
+        train_ds, val_ds, model = _make_dummy(cfg.get("dummy", {}))
+        loader_cfg = {"batch_size": 64, "num_workers": 0, "pin_memory": False}
+    else:
+        data_cfg = cfg.get("data", {})
+        train_ds = build_from_target(data_cfg["train"])
+        val_ds = build_from_target(data_cfg["val"]) if "val" in data_cfg and data_cfg["val"] else None
+        loader_cfg = data_cfg.get("loader", {"batch_size": 16, "num_workers": 0, "pin_memory": False})
 
-    # Model
-    if torch is None:
-        raise RuntimeError("PyTorch is required for training.")
-    model = _build_model(cfg)
-    model.to(device)
-    _ensure_cuda_graph_compat(model)
+        model_cfg = cfg.get("model")
+        if not model_cfg:
+            raise ValueError("Missing 'model' config block.")
+        model = build_from_target(model_cfg)
 
-    # Optim + Sched
-    optimizer = _build_optimizer(model, cfg)
-    scheduler = _build_scheduler(optimizer, cfg, train_len=len(train_loader))
+    train_loader = _dataloader(train_ds, loader_cfg)
+    val_loader = _dataloader(val_ds, {**loader_cfg, "shuffle": False}) if val_ds is not None else None
 
-    # Callbacks
-    ckpt_dir = cfg["trainer"].get("ckpt_dir", "artifacts/checkpoints")
-    checker = Checkpointer(
-        ckpt_dir, keep_last=int(cfg["trainer"].get("keep_last", 5))
+    # --- Loss & Step Processor ---
+    loss = _build_loss(cfg.get("loss", {}))
+    step_proc_cfg = cfg.get("step_processor", {"target": "spectramind.train.step_processors:GenericGaussianProcessor", "params": {}})
+    step_proc = build_from_target({**step_proc_cfg, "params": {**(step_proc_cfg.get("params") or {}), "loss_module": loss}})
+
+    # --- Optimizer & Scheduler ---
+    optim_cfg = cfg.get("optim", {"name": "adamw", "lr": 3e-4, "weight_decay": 0.01})
+    optimizer = build_optimizer(model, optim_cfg)
+
+    total_steps = math.ceil(len(train_loader) / max(1, int(cfg.get("train", {}).get("grad_accum", 1)))) * int(cfg.get("train", {}).get("epochs", 10))
+    sched = build_scheduler(optimizer, cfg.get("sched"), total_steps=total_steps)
+
+    # --- Trainer ---
+    train_cfg = cfg.get("train", {})
+    ckpt = CheckpointManager(out_dir)
+    early = EarlyStopping(monitor="val_loss", mode="min", patience=int(train_cfg.get("patience", 10)))
+
+    trainer = TrainerBase(
+        model=model,
+        optimizer=optimizer,
+        scheduler=sched,
+        step_fn=step_proc,
+        device=device,
+        logger=logger,
+        grad_accum_steps=int(train_cfg.get("grad_accum", 1)),
+        use_amp=bool(train_cfg.get("amp", True)),
+        clip_grad_norm=float(train_cfg.get("clip_grad_norm", 1.0)) if train_cfg.get("clip_grad_norm", None) is not None else None,
+        checkpoint=ckpt,
+        early_stopping=early if val_loader is not None else None,
+        hooks=TrainerHooks(),
     )
-    early = EarlyStopper(
-        patience=int(cfg["trainer"]["early_stop"].get("patience", 7)),
-        min_delta=float(cfg["trainer"]["early_stop"].get("min_delta", 0.0)),
-        metric_name="val_loss",
+
+    # Snapshot config for reproducibility
+    dump_yaml_safely(cfg, os.path.join(out_dir, "config_snapshot.yaml"))
+
+    # --- Train ---
+    summary = trainer.fit(
+        train_loader=train_loader,
+        val_loader=val_loader,
+        epochs=int(train_cfg.get("epochs", 10)),
+        start_epoch=1,
     )
 
-    # Loop
-    global_step = 0
-    best_path = None
-    for epoch in range(1, int(cfg["trainer"]["max_epochs"]) + 1):
-        logger.info(f"Epoch {epoch}/{cfg['trainer']['max_epochs']}")
-        global_step, train_avg = _train_one_epoch(
-            model, train_loader, optimizer, scheduler, cfg, global_step
-        )
-        for k, v in (train_avg or {}).items():
-            write_jsonl({"event": "train_epoch_avg", "epoch": epoch, k: float(v)})
-        # Val
-        val_metrics = _evaluate(model, val_loader, cfg)
-        _log_val_metrics(epoch, val_metrics)
-        # Checkpointing
-        if epoch % int(cfg["trainer"].get("save_every_epochs", 1)) == 0:
-            checker.save_periodic(
-                {
-                    "epoch": epoch,
-                    "model": model.state_dict(),
-                    "optimizer": optimizer.state_dict(),
-                    "scheduler": (
-                        None
-                        if scheduler is None
-                        else scheduler.state_dict()
-                        if hasattr(scheduler, "state_dict")
-                        else {}
-                    ),
-                    "step": global_step,
-                    "cfg": cfg,
-                },
-                tag=f"epoch_{epoch:03d}",
-            )
-        best_maybe = checker.try_save_best(
-            {
-                "epoch": epoch,
-                "model": model.state_dict(),
-                "optimizer": optimizer.state_dict(),
-                "scheduler": (
-                    None
-                    if scheduler is None
-                    else scheduler.state_dict()
-                    if hasattr(scheduler, "state_dict")
-                    else {}
-                ),
-                "step": global_step,
-                "cfg": cfg,
-            },
-            value=float(val_metrics.get("val_loss", float("inf"))),
-        )
-        if best_maybe:
-            best_path = best_maybe
-        # Early stop
-        if early.step(value=float(val_metrics.get("val_loss", float("inf")))):
-            logger.info(
-                f"Early stopping triggered at epoch {epoch} with best {early.best:.6f}."
-            )
-            break
+    logger.info(f"Training completed. Best val loss: {summary['best_val_loss']:.6f}")
+    logger.close()
+    return summary
 
-    # Finalize
-    try_mlflow_end()
-    manifest = {
-        "best_checkpoint": best_path,
-        "cfg_hash": meta.config_hash,
-        "events_jsonl": "train_events.jsonl",
-        "log_file": "logs/train.log",
+
+if __name__ == "__main__":
+    # Minimal CLI to run dummy smoke test if no external CLI provided.
+    # Example:
+    #   python -m src.spectramind.train.train_v50
+    cfg = {
+        "run": {"name": "v50-dummy", "out_dir": "runs/v50-dummy", "seed": 1337, "device": "cpu", "mlflow": False},
+        "dummy_mode": True,
+        "dummy": {"dummy_dims": 64, "dummy_bins": 32},
+        "loss": {
+            "main": {"target": "spectramind.train.losses:GaussianLikelihoodLoss", "params": {"min_sigma": 1e-3}},
+            "weights": {"lambda_smooth": 0.0, "lambda_asym": 0.0},
+        },
+        "optim": {"name": "adamw", "lr": 1e-3, "weight_decay": 0.01},
+        "sched": {"name": "cosine_warmup", "warmup_steps": 50},
+        "train": {"epochs": 3, "grad_accum": 1, "amp": False, "clip_grad_norm": 1.0, "patience": 3},
     }
-    from .common import export_manifest
-
-    export_manifest(manifest, out_path="artifacts/train_manifest.json")
-    return manifest
-
-
-if hydra is not None:
-
-    @hydra.main(config_path=None, config_name=None, version_base=None)
-    def _main(cfg):  # type: ignore
-        """Hydra entrypoint. Accepts a composed config dictionary.
-
-        Usage:
-            python -m src.spectramind.train.train_v50 +trainer.max_epochs=2
-        """
-        # Convert OmegaConf to plain dict for hashing and logging
-        cfg_dict = OmegaConf.to_container(cfg, resolve=True)  # type: ignore
-        run_training(cfg_dict)  # type: ignore
-
-
-if __name__ == "__main__":  # pragma: no cover
-    if hydra is None:
-        raise SystemExit("Hydra is required to run this module as a script.")
-    _main()  # type: ignore
-
+    run_train(cfg)

--- a/src/spectramind/train/trainer_base.py
+++ b/src/spectramind/train/trainer_base.py
@@ -1,0 +1,156 @@
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import torch
+from torch.utils.data import DataLoader
+
+from .callbacks import EarlyStopping, CheckpointManager
+from .experiment_logger import ExperimentLogger
+
+
+@dataclass
+class TrainerHooks:
+    """
+    Optional hooks to customize per-epoch behavior.
+    """
+    on_epoch_start: Optional[Callable[[int], None]] = None
+    on_epoch_end: Optional[Callable[[int, Dict[str, float], Dict[str, float]], None]] = None
+    on_validation_end: Optional[Callable[[int, Dict[str, float]], None]] = None
+
+
+class TrainerBase:
+    """
+    Mission-grade trainer with AMP, grad accumulation, early stopping, and checkpointing.
+    Accepts a 'step_fn(model, batch, device) -> (loss_tensor, metrics_dict)' callable.
+    """
+
+    def __init__(
+        self,
+        model: torch.nn.Module,
+        optimizer: torch.optim.Optimizer,
+        step_fn: Callable[[torch.nn.Module, Dict, torch.device], Tuple[torch.Tensor, Dict[str, float]]],
+        device: torch.device,
+        logger: ExperimentLogger,
+        scheduler=None,
+        grad_accum_steps: int = 1,
+        use_amp: bool = True,
+        clip_grad_norm: Optional[float] = None,
+        checkpoint: Optional[CheckpointManager] = None,
+        early_stopping: Optional[EarlyStopping] = None,
+        hooks: Optional[TrainerHooks] = None,
+    ) -> None:
+        self.model = model.to(device)
+        self.optimizer = optimizer
+        self.scheduler = scheduler
+        self.step_fn = step_fn
+        self.device = device
+        self.logger = logger
+        self.grad_accum_steps = max(1, int(grad_accum_steps))
+        self.use_amp = use_amp
+        self.clip_grad_norm = clip_grad_norm
+        self.checkpoint = checkpoint
+        self.early_stopping = early_stopping
+        self.hooks = hooks or TrainerHooks()
+        self.scaler = torch.cuda.amp.GradScaler(enabled=use_amp)
+
+    def _run_split(self, loader: DataLoader, train: bool) -> Dict[str, float]:
+        if train:
+            self.model.train()
+        else:
+            self.model.eval()
+
+        total_loss = 0.0
+        metrics_accum: Dict[str, float] = {}
+        num_steps = 0
+
+        for step, batch in enumerate(loader):
+            if train:
+                with torch.cuda.amp.autocast(enabled=self.use_amp):
+                    loss, scalars = self.step_fn(self.model, batch, self.device)
+                    loss = loss / self.grad_accum_steps
+                self.scaler.scale(loss).backward()
+
+                if self.clip_grad_norm is not None:
+                    self.scaler.unscale_(self.optimizer)
+                    torch.nn.utils.clip_grad_norm_(self.model.parameters(), self.clip_grad_norm)
+
+                if (step + 1) % self.grad_accum_steps == 0:
+                    self.scaler.step(self.optimizer)
+                    self.scaler.update()
+                    self.optimizer.zero_grad(set_to_none=True)
+                    if self.scheduler is not None and hasattr(self.scheduler, "step") and not hasattr(self.scheduler, "step_on_epoch"):
+                        self.scheduler.step()
+            else:
+                with torch.no_grad():
+                    loss, scalars = self.step_fn(self.model, batch, self.device)
+
+            total_loss += float(loss.detach().item())
+            for k, v in scalars.items():
+                metrics_accum[k] = metrics_accum.get(k, 0.0) + float(v)
+            num_steps += 1
+
+        # Normalize
+        if num_steps > 0:
+            total_loss /= num_steps
+            for k in list(metrics_accum.keys()):
+                metrics_accum[k] /= num_steps
+
+        metrics_accum["loss"] = total_loss
+        return metrics_accum
+
+    def fit(
+        self,
+        train_loader: DataLoader,
+        val_loader: Optional[DataLoader],
+        epochs: int,
+        start_epoch: int = 1,
+    ) -> Dict[str, float]:
+        best_val = float("inf")
+        for epoch in range(start_epoch, start_epoch + epochs):
+            if self.hooks.on_epoch_start:
+                self.hooks.on_epoch_start(epoch)
+
+            train_metrics = self._run_split(train_loader, train=True)
+            self.logger.log_metrics(train_metrics, step=epoch, split="train")
+
+            val_metrics = {}
+            if val_loader is not None:
+                val_metrics = self._run_split(val_loader, train=False)
+                self.logger.log_metrics(val_metrics, step=epoch, split="val")
+
+            # epoch-level scheduler (if provided)
+            if self.scheduler is not None and hasattr(self.scheduler, "step_on_epoch"):
+                self.scheduler.step_on_epoch()  # custom semantics
+            elif self.scheduler is not None and hasattr(self.scheduler, "step") and hasattr(self.scheduler, "step_on_epoch_only"):
+                self.scheduler.step()
+
+            if self.hooks.on_validation_end:
+                self.hooks.on_validation_end(epoch, val_metrics)
+
+            # checkpointing
+            to_save = {
+                "epoch": epoch,
+                "model_state": self.model.state_dict(),
+                "optimizer_state": self.optimizer.state_dict(),
+                "train_metrics": train_metrics,
+                "val_metrics": val_metrics,
+            }
+            if self.checkpoint is not None:
+                self.checkpoint.save_last(to_save)
+                # monitor val loss by default
+                monitor_val = val_metrics.get("loss", float("inf")) if val_metrics else train_metrics.get("loss", float("inf"))
+                if monitor_val < best_val:
+                    best_val = monitor_val
+                    self.checkpoint.save_best(to_save)
+
+            # early stopping
+            if self.early_stopping is not None and val_metrics:
+                should_stop = self.early_stopping.step({"val_loss": val_metrics.get("loss", float("inf"))})
+                if should_stop:
+                    self.logger.info(f"Early stopping at epoch {epoch}. Best={self.early_stopping.best:.6f}")
+                    break
+
+            if self.hooks.on_epoch_end:
+                self.hooks.on_epoch_end(epoch, train_metrics, val_metrics)
+
+        return {"best_val_loss": best_val}

--- a/src/spectramind/train/utils.py
+++ b/src/spectramind/train/utils.py
@@ -1,0 +1,105 @@
+import json
+import os
+import random
+import socket
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import numpy as np
+import torch
+
+try:
+    from omegaconf import OmegaConf
+except Exception:  # pragma: no cover - OmegaConf optional at runtime
+    OmegaConf = None  # type: ignore
+
+def seed_everything(seed: int = 1337, deterministic: bool = True) -> None:
+    """
+    Seed Python, NumPy, and PyTorch RNGs for determinism.
+    Optionally enable cuDNN deterministic behavior (may impact performance).
+    """
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    if deterministic:
+        torch.backends.cudnn.benchmark = False  # type: ignore[attr-defined]
+        torch.backends.cudnn.deterministic = True  # type: ignore[attr-defined]
+
+def get_device(prefer: str = "cuda") -> torch.device:
+    """
+    Select a torch.device with preference ordering.
+    prefer: "cuda" | "mps" | "cpu"
+    """
+    prefer = prefer.lower()
+    if prefer == "cuda" and torch.cuda.is_available():
+        return torch.device("cuda")
+    if prefer in ("mps", "metal"):
+        if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():  # type: ignore
+            return torch.device("mps")
+    return torch.device("cpu")
+
+def count_parameters(model: torch.nn.Module, trainable_only: bool = True) -> int:
+    """
+    Count model parameters. If trainable_only=True, only parameters with requires_grad.
+    """
+    if trainable_only:
+        return sum(p.numel() for p in model.parameters() if p.requires_grad)
+    return sum(p.numel() for p in model.parameters())
+
+def git_commit_hash() -> Optional[str]:
+    """
+    Return the current Git commit hash if within a Git repo; else None.
+    """
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL).decode().strip()
+    except Exception:
+        return None
+
+def dump_yaml_safely(obj: Any, path: str) -> None:
+    """
+    Dump a Python object to path as YAML if OmegaConf is available, else JSON.
+    Ensures we can always write a serializable snapshot.
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    if OmegaConf is not None:
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(OmegaConf.to_yaml(OmegaConf.create(obj)))  # type: ignore
+    else:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(obj, f, indent=2, sort_keys=True)
+
+@dataclass
+class RunContext:
+    """
+    Minimal run context describing runtime environment for logging & reproducibility.
+    """
+    hostname: str
+    pid: int
+    python: str
+    argv: str
+    cwd: str
+    time_utc: float
+    git_hash: Optional[str]
+
+    @staticmethod
+    def capture() -> "RunContext":
+        return RunContext(
+            hostname=socket.gethostname(),
+            pid=os.getpid(),
+            python=sys.version.replace("\n", " "),
+            argv=" ".join(sys.argv),
+            cwd=str(Path.cwd()),
+            time_utc=time.time(),
+            git_hash=git_commit_hash(),
+        )
+
+def ensure_dir(path: str) -> None:
+    """
+    Create directory if missing; no error if exists.
+    """
+    os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
## Summary
- implement SpectraMind V50 training utilities with deterministic seeding, logging, JSONL event stream, and optional MLflow hooks
- add TrainerBase with AMP, gradient accumulation, checkpointing, and early stopping
- provide self-test harness and documentation

## Testing
- `python -m src.spectramind.train.selftest` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pytest tests/training/test_package_imports.py::test_training_package_public_api -q` *(skipped: could not import 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a0a0b7567c832a95ad74f3faedcb24