### PR TITLE
Fix multiprocessing worker tuple handling

### DIFF
--- a/src/spectramind/utils/parallel.py
+++ b/src/spectramind/utils/parallel.py
@@ -1,5 +1,5 @@
 import multiprocessing as mp
-from typing import Callable, Iterable, List, Any, Sequence
+from typing import Callable, Iterable, List, Any, Sequence, Tuple
 
 
 def cpu_count_safe(default: int = 2) -> int:
@@ -18,7 +18,9 @@ def chunked(seq: Sequence[Any], n: int) -> List[Sequence[Any]]:
     return [seq[i : i + size] for i in range(0, L, size)]
 
 
-def _worker(fn: Callable[[Any], Any], item: Any) -> Any:
+def _worker(args: Tuple[Callable[[Any], Any], Any]) -> Any:
+    """Unpack function and item for pool workers."""
+    fn, item = args
     return fn(item)
 
 


### PR DESCRIPTION
## Summary
- fix `run_parallel` worker function to unpack `(fn, item)` tuple

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a93e17f8832a83fc4a3cde05b1f4