### PR TITLE
feat: add hydra model factory and configs

### DIFF
--- a/configs/model/README.md
+++ b/configs/model/README.md
@@ -1,0 +1,29 @@
+# SpectraMind V50 — Model Hydra Group
+
+This folder contains the Hydra config group for assembling the SpectraMind V50 model stack.
+
+## Quick Start
+Use the master group:
+- `model=model` to load default components:
+  - `encoder_fgs1: fgs1_mamba`
+  - `encoder_airs: airs_gnn`
+  - `decoder_mu: multi_scale_decoder`
+  - `decoder_sigma: flow_uncertainty_head`
+  - `corel: spectral_corel`
+
+Override any subgroup at runtime, for example:
+```
+
+python -m spectramind.cli_core_v50 train model.decoder_mu=moe_decoder
+
+```
+
+Or override parameters:
+```
+
+python -m spectramind.cli_core_v50 train model.encoder_airs.hidden_dim=192
+
+```
+
+The Python factory at `src/spectramind/models/factory.py` consumes `cfg.model` and returns a
+`BuiltModels` container with ready-to-use modules for training/inference.

--- a/configs/model/corel/spectral_corel.yaml
+++ b/configs/model/corel/spectral_corel.yaml
@@ -1,0 +1,6 @@
+# configs/model/corel/spectral_corel.yaml
+# Spectral COREL binwise calibration GNN with edge features.
+_name: spectral_corel
+input_dim: 283
+hidden_dim: 128
+output_dim: 283

--- a/configs/model/decoder_mu/moe_decoder.yaml
+++ b/configs/model/decoder_mu/moe_decoder.yaml
@@ -1,0 +1,6 @@
+# configs/model/decoder_mu/moe_decoder.yaml
+# Mixture-of-Experts μ decoder with expert attention weights.
+_name: moe_decoder
+hidden_dim: 128
+output_bins: 283
+num_experts: 4

--- a/configs/model/decoder_mu/multi_scale_decoder.yaml
+++ b/configs/model/decoder_mu/multi_scale_decoder.yaml
@@ -1,0 +1,5 @@
+# configs/model/decoder_mu/multi_scale_decoder.yaml
+# Multi-scale μ decoder aggregating FGS1/AIRS latents.
+_name: multi_scale_decoder
+hidden_dim: 128       # internal fusion/hidden dim
+output_bins: 283      # number of spectral bins in challenge output

--- a/configs/model/decoder_sigma/flow_uncertainty_head.yaml
+++ b/configs/model/decoder_sigma/flow_uncertainty_head.yaml
@@ -1,0 +1,5 @@
+# configs/model/decoder_sigma/flow_uncertainty_head.yaml
+# Flow-based σ head (simple exponential positivity enforcement here).
+_name: flow_uncertainty_head
+hidden_dim: 128
+output_bins: 283

--- a/configs/model/encoder_airs/airs_gnn.yaml
+++ b/configs/model/encoder_airs/airs_gnn.yaml
@@ -1,0 +1,7 @@
+# configs/model/encoder_airs/airs_gnn.yaml
+# AIRS spectral GNN encoder with attention and edge features.
+_name: airs_gnn
+input_dim: 356        # node feature size (per wavelength bin/node)
+hidden_dim: 128       # latent dim
+num_layers: 4         # GNN depth
+dropout: 0.10         # dropout after each layer

--- a/configs/model/encoder_fgs1/fgs1_mamba.yaml
+++ b/configs/model/encoder_fgs1/fgs1_mamba.yaml
@@ -1,0 +1,7 @@
+# configs/model/encoder_fgs1/fgs1_mamba.yaml
+# FGS1 long-sequence encoder (Mamba/Transformer stand-in).
+_name: fgs1_mamba
+input_dim: 32         # channels/features per timestep
+hidden_dim: 128       # latent dim
+depth: 12             # number of encoder blocks
+dropout: 0.10         # dropout within blocks

--- a/configs/model/model.yaml
+++ b/configs/model/model.yaml
@@ -1,0 +1,22 @@
+# configs/model/model.yaml
+# Master model group for SpectraMind V50. Compose subgroups here.
+# Usage:
+#   python -m spectramind.cli_core_v50 train model=model   # or via spectramind CLI
+#
+# You can override any subgroup, e.g.:
+#   model:
+#     decoder_mu: moe_decoder
+# or with Hydra CLI:
+#   python -m spectramind.cli_core_v50 train model.decoder_mu=moe_decoder
+
+defaults:
+  - encoder_fgs1: fgs1_mamba
+  - encoder_airs: airs_gnn
+  - decoder_mu: multi_scale_decoder
+  - decoder_sigma: flow_uncertainty_head
+  - corel: spectral_corel
+
+# The nested sections below are materialized by the defaults via Hydra's group mechanism.
+# We also keep top-level convenience mirrors (read-only) for quick reference in dashboards.
+name: "SpectraMindV50"
+description: "FGS1 Mamba + AIRS GNN + MultiScale μ + Flow σ + SpectralCOREL"

--- a/src/spectramind/models/__init__.py
+++ b/src/spectramind/models/__init__.py
@@ -29,3 +29,5 @@ __all__ = [
     "register_model",
 ]
 
+
+from .factory import build_from_cfg, BuiltModels

--- a/src/spectramind/models/factory.py
+++ b/src/spectramind/models/factory.py
@@ -1,0 +1,175 @@
+# src/spectramind/models/factory.py
+# -----------------------------------------------------------------------------
+# Hydra-aware factory for SpectraMind V50 model components.
+# Builds encoders/decoders/heads from cfg.model.* groups, logs config hashes,
+# and returns a structured dict ready for training/inference pipelines.
+# -----------------------------------------------------------------------------
+
+from __future__ import annotations
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+from omegaconf import DictConfig, OmegaConf
+
+# Local imports of concrete classes
+from .fgs1_mamba import FGS1MambaEncoder
+from .airs_gnn import AIRSSpectralGNN
+from .multi_scale_decoder import MultiScaleDecoder
+from .moe_decoder import MoEDecoder
+from .flow_uncertainty_head import FlowUncertaintyHead
+from .spectral_corel import SpectralCOREL
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BuiltModels:
+    """Container for all assembled model components."""
+    fgs1_encoder: Any
+    airs_encoder: Any
+    mu_decoder: Any
+    sigma_head: Any
+    corel: Optional[Any] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "fgs1_encoder": self.fgs1_encoder,
+            "airs_encoder": self.airs_encoder,
+            "mu_decoder": self.mu_decoder,
+            "sigma_head": self.sigma_head,
+            "corel": self.corel,
+        }
+
+
+def _hash_cfg_section(cfg_section: DictConfig) -> str:
+    """Create a stable hash for a config section for reproducibility logs."""
+    # Convert to a JSON-serializable primitive dict
+    primitive = OmegaConf.to_container(cfg_section, resolve=True)
+    blob = json.dumps(primitive, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()[:12]
+
+
+def _build_fgs1_encoder(cfg: DictConfig):
+    name = cfg.encoder_fgs1._name
+    if name != "fgs1_mamba":
+        raise ValueError(f"Unsupported FGS1 encoder: {name}")
+    enc = FGS1MambaEncoder(
+        input_dim=cfg.encoder_fgs1.input_dim,
+        hidden_dim=cfg.encoder_fgs1.hidden_dim,
+        depth=cfg.encoder_fgs1.depth,
+        dropout=cfg.encoder_fgs1.dropout,
+    )
+    logger.info("FGS1 encoder built (%s) cfg_hash=%s", name, _hash_cfg_section(cfg.encoder_fgs1))
+    return enc
+
+
+def _build_airs_encoder(cfg: DictConfig):
+    name = cfg.encoder_airs._name
+    if name != "airs_gnn":
+        raise ValueError(f"Unsupported AIRS encoder: {name}")
+    enc = AIRSSpectralGNN(
+        input_dim=cfg.encoder_airs.input_dim,
+        hidden_dim=cfg.encoder_airs.hidden_dim,
+        num_layers=cfg.encoder_airs.num_layers,
+        dropout=cfg.encoder_airs.dropout,
+    )
+    logger.info("AIRS encoder built (%s) cfg_hash=%s", name, _hash_cfg_section(cfg.encoder_airs))
+    return enc
+
+
+def _build_mu_decoder(cfg: DictConfig, hidden_dim_fgs1: int, hidden_dim_airs: int):
+    name = cfg.decoder_mu._name
+    if name == "multi_scale_decoder":
+        dec = MultiScaleDecoder(
+            hidden_dim=cfg.decoder_mu.hidden_dim,
+            output_bins=cfg.decoder_mu.output_bins,
+        )
+    elif name == "moe_decoder":
+        dec = MoEDecoder(
+            hidden_dim=cfg.decoder_mu.hidden_dim,
+            output_bins=cfg.decoder_mu.output_bins,
+            num_experts=cfg.decoder_mu.num_experts,
+        )
+    else:
+        raise ValueError(f"Unsupported μ decoder: {name}")
+    logger.info("μ decoder built (%s) cfg_hash=%s", name, _hash_cfg_section(cfg.decoder_mu))
+    return dec
+
+
+def _build_sigma_head(cfg: DictConfig):
+    name = cfg.decoder_sigma._name
+    if name != "flow_uncertainty_head":
+        raise ValueError(f"Unsupported σ head: {name}")
+    head = FlowUncertaintyHead(
+        hidden_dim=cfg.decoder_sigma.hidden_dim,
+        output_bins=cfg.decoder_sigma.output_bins,
+    )
+    logger.info("σ head built (%s) cfg_hash=%s", name, _hash_cfg_section(cfg.decoder_sigma))
+    return head
+
+
+def _build_corel(cfg: DictConfig):
+    name = cfg.corel._name
+    if name != "spectral_corel":
+        raise ValueError(f"Unsupported COREL GNN: {name}")
+    corel = SpectralCOREL(
+        input_dim=cfg.corel.input_dim,
+        hidden_dim=cfg.corel.hidden_dim,
+        output_dim=cfg.corel.output_dim,
+    )
+    logger.info("COREL built (%s) cfg_hash=%s", name, _hash_cfg_section(cfg.corel))
+    return corel
+
+
+def build_from_cfg(cfg: DictConfig) -> BuiltModels:
+    """
+    Build all model components from Hydra config section `cfg.model`.
+
+    Expected structure (see configs/model/model.yaml):
+        model:
+          defaults:
+            - encoder_fgs1: fgs1_mamba
+            - encoder_airs: airs_gnn
+            - decoder_mu: multi_scale_decoder
+            - decoder_sigma: flow_uncertainty_head
+            - corel: spectral_corel
+          ...
+
+    Returns:
+        BuiltModels: container with all ready-to-use modules.
+    """
+    if "model" in cfg:
+        model_cfg = cfg.model
+    else:
+        model_cfg = cfg
+
+    # Build encoders
+    fgs1_encoder = _build_fgs1_encoder(model_cfg)
+    airs_encoder = _build_airs_encoder(model_cfg)
+
+    # Infer hidden dims to pass to decoders if needed
+    hidden_dim_fgs1 = model_cfg.encoder_fgs1.hidden_dim
+    hidden_dim_airs = model_cfg.encoder_airs.hidden_dim
+
+    # Build decoders/heads
+    mu_decoder = _build_mu_decoder(model_cfg, hidden_dim_fgs1, hidden_dim_airs)
+    sigma_head = _build_sigma_head(model_cfg)
+
+    # Optional COREL (enabled by default in our model group)
+    corel = _build_corel(model_cfg) if "_name" in model_cfg.corel and model_cfg.corel._name else None
+
+    built = BuiltModels(
+        fgs1_encoder=fgs1_encoder,
+        airs_encoder=airs_encoder,
+        mu_decoder=mu_decoder,
+        sigma_head=sigma_head,
+        corel=corel,
+    )
+
+    # Log a single combined hash for the whole model subtree for reproducibility
+    model_hash = _hash_cfg_section(model_cfg)
+    logger.info("Built full SpectraMind model stack; model_cfg_hash=%s", model_hash)
+    return built

--- a/src/spectramind/models/tests/test_build_from_cfg.py
+++ b/src/spectramind/models/tests/test_build_from_cfg.py
@@ -1,0 +1,35 @@
+# src/spectramind/models/tests/test_build_from_cfg.py
+# Simple smoke tests to ensure Hydra configs instantiate the full model stack.
+
+from omegaconf import OmegaConf
+from spectramind.models import build_from_cfg
+
+def test_build_defaults():
+    base = OmegaConf.create({
+        "model": {
+            "encoder_fgs1": {"_name": "fgs1_mamba", "input_dim": 32, "hidden_dim": 128, "depth": 12, "dropout": 0.1},
+            "encoder_airs": {"_name": "airs_gnn", "input_dim": 356, "hidden_dim": 128, "num_layers": 4, "dropout": 0.1},
+            "decoder_mu": {"_name": "multi_scale_decoder", "hidden_dim": 128, "output_bins": 283},
+            "decoder_sigma": {"_name": "flow_uncertainty_head", "hidden_dim": 128, "output_bins": 283},
+            "corel": {"_name": "spectral_corel", "input_dim": 283, "hidden_dim": 128, "output_dim": 283},
+        }
+    })
+    built = build_from_cfg(base)
+    assert built.fgs1_encoder is not None
+    assert built.airs_encoder is not None
+    assert built.mu_decoder is not None
+    assert built.sigma_head is not None
+    assert built.corel is not None
+
+def test_build_moe_decoder():
+    base = OmegaConf.create({
+        "model": {
+            "encoder_fgs1": {"_name": "fgs1_mamba", "input_dim": 32, "hidden_dim": 128, "depth": 12, "dropout": 0.1},
+            "encoder_airs": {"_name": "airs_gnn", "input_dim": 356, "hidden_dim": 128, "num_layers": 4, "dropout": 0.1},
+            "decoder_mu": {"_name": "moe_decoder", "hidden_dim": 128, "output_bins": 283, "num_experts": 4},
+            "decoder_sigma": {"_name": "flow_uncertainty_head", "hidden_dim": 128, "output_bins": 283},
+            "corel": {"_name": "spectral_corel", "input_dim": 283, "hidden_dim": 128, "output_dim": 283},
+        }
+    })
+    built = build_from_cfg(base)
+    assert built.mu_decoder is not None


### PR DESCRIPTION
## Summary
- add Hydra-aware model factory for assembling encoders, decoders and heads
- introduce structured model config groups and defaults
- add smoke tests for config-driven model builds

## Testing
- `pytest src/spectramind/models/tests/test_build_from_cfg.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu -q` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b7ff9dac832a83e092f72f0c5877