### PR TITLE
Add configuration helpers and CLI integration

### DIFF
--- a/spectramind.py
+++ b/spectramind.py
@@ -1,30 +1,89 @@
 #!/usr/bin/env python
 import json
-import typer
+from typing import List, Optional
+
 import torch
-from typing import Optional
+import typer
 
 from src.spectramind.diagnostics import selftest_diagnostics
+
 try:
     from omegaconf import OmegaConf
-except Exception:
+except Exception:  # pragma: no cover - optional dependency
     OmegaConf = None
 
+from spectramind.conf_helpers import (
+    apply_overrides,
+    cli_override_parser,
+    inject_symbolic_constraints,
+    load_config,
+    log_environment,
+    validate_config,
+)
 from src.spectramind.models import create_fusion
 
 app = typer.Typer(help="SpectraMind V50 unified CLI")
 
+config_app = typer.Typer(
+    help="Configuration utilities (Hydra, overrides, validation, env)"
+)
+app.add_typer(config_app, name="config")
+
+
+@config_app.command("validate")
+def config_validate(config: str, schema: str) -> None:
+    """Validate a YAML config against a JSON schema."""
+    cfg = load_config(config)
+    ok = validate_config(cfg, schema)
+    if ok:
+        typer.echo(f"\u2705 Config {config} is valid against schema {schema}")
+
+
+@config_app.command("apply-override")
+def config_apply_override(config: str, overrides: List[str]) -> None:
+    """Apply CLI-style overrides to a config and print result."""
+    cfg = load_config(config)
+    parsed = cli_override_parser(overrides)
+    cfg = apply_overrides(cfg, parsed)
+    typer.echo(cfg.pretty())
+
+
+@config_app.command("capture-env")
+def config_capture_env(out: str = "env_capture.json") -> None:
+    """Capture environment metadata and save to file."""
+    env = log_environment(out)
+    typer.echo(f"\u2705 Environment captured in {out}")
+    typer.echo(env)
+
+
+@config_app.command("inject-symbolic")
+def config_inject_symbolic(config: str) -> None:
+    """Inject default symbolic constraint weights into a config."""
+    cfg = load_config(config)
+    cfg = inject_symbolic_constraints(cfg)
+    typer.echo(cfg.pretty())
+
+
 @app.command("fusion-smoke")
 def fusion_smoke(
     config: Optional[str] = typer.Option(None, help="Path to fusion YAML (variant)"),
-    base:   Optional[str] = typer.Option(None, help="Path to base fusion YAML"),
-    ftype:  Optional[str] = typer.Option("concat+mlp", help="Override type if YAMLs not provided"),
-    dim:    int = typer.Option(64, help="Model fused dim / also used as d_fgs1/d_airs if no YAMLs"),
-):
+    base: Optional[str] = typer.Option(None, help="Path to base fusion YAML"),
+    ftype: Optional[str] = typer.Option(
+        "concat+mlp", help="Override type if YAMLs not provided"
+    ),
+    dim: int = typer.Option(
+        64,
+        help="Model fused dim / also used as d_fgs1/d_airs if no YAMLs",
+    ),
+) -> None:
     if OmegaConf and config and base:
         base_cfg = OmegaConf.load(base)
-        var_cfg  = OmegaConf.load(config)
-        merged = OmegaConf.merge({"model": {"fusion": {}}}, {"model": {"fusion": dict(base_cfg)}}, {"model": {"fusion": dict(var_cfg)}})
+        var_cfg = OmegaConf.load(config)
+        merged = OmegaConf.merge(
+            {"model": {"fusion": {}}},
+            {"model": {"fusion": dict(base_cfg)}},
+            {"model": {"fusion": dict(var_cfg)}},
+        )
         cfg = OmegaConf.to_container(merged, resolve=True)
     else:
         cfg = {
@@ -34,8 +93,16 @@ def fusion_smoke(
                     "dim": dim,
                     "dropout": 0.05,
                     "norm": "layernorm",
-                    "export": {"taps": True, "attn_weights": True, "gate_values": True},
-                    "shapes": {"d_fgs1": dim, "d_airs": dim, "strict_check": True},
+                    "export": {
+                        "taps": True,
+                        "attn_weights": True,
+                        "gate_values": True,
+                    },
+                    "shapes": {
+                        "d_fgs1": dim,
+                        "d_airs": dim,
+                        "strict_check": True,
+                    },
                 }
             }
         }
@@ -49,9 +116,12 @@ def fusion_smoke(
 
 
 @app.command("diagnose")
-def diagnose(outdir: str = typer.Option("diagnostics", help="Output directory")):
+def diagnose(
+    outdir: str = typer.Option("diagnostics", help="Output directory"),
+) -> None:
     """Run SpectraMind diagnostics self-test."""
     selftest_diagnostics.run_selftest(outdir)
+
 
 if __name__ == "__main__":
     app()

--- a/src/spectramind/conf_helpers/README.md
+++ b/src/spectramind/conf_helpers/README.md
@@ -1,0 +1,13 @@
+# Configuration Helpers
+
+Utility helpers for loading, validating and manipulating SpectraMind
+configuration files.  These modules expose a small API that is also
+integrated into the root ``spectramind`` CLI.
+
+Functions provided include:
+
+- ``load_config`` / ``save_config`` for basic YAML IO.
+- ``cli_override_parser`` and ``apply_overrides`` for Hydra-style CLI overrides.
+- ``validate_config`` for JSON schema validation.
+- ``inject_symbolic_constraints`` for default symbolic weights.
+- ``capture_environment`` / ``log_environment`` for environment metadata.

--- a/src/spectramind/conf_helpers/__init__.py
+++ b/src/spectramind/conf_helpers/__init__.py
@@ -2,28 +2,31 @@
 
 """SpectraMind V50 configuration helper package."""
 
+from .config_loader import load_config, save_config
+from .env_capture import capture_environment, log_environment
 from .exceptions import (
-    ConfigValidationError,
-    OverrideLoadError,
-    HydraLoadError,
-    SchemaExportError,
     ConfHelpersError,
+    ConfigValidationError,
+    HydraLoadError,
+    OverrideLoadError,
+    SchemaExportError,
 )
-
-from .schema import V50ConfigSchema, get_json_schema
 from .hashing import config_hash, stable_dumps
-from .io import load_yaml, save_yaml, load_json, save_json, atomic_write
-from .logging_utils import (
-    get_logger,
-    log_event,
-    init_logging,
-    LOG_JSONL,
-    V50_DEBUG_LOG,
-)
 from .hydra_integration import load_config_hydra
-from .validators import validate_config
-from .overrides import apply_symbolic_overrides, deep_update, load_overrides_layered
+from .io import atomic_write, load_json, load_yaml, save_json, save_yaml
 from .loader import load_and_validate
+from .logging_utils import LOG_JSONL, V50_DEBUG_LOG, get_logger, init_logging, log_event
+from .overrides import (
+    apply_overrides,
+    apply_symbolic_overrides,
+    cli_override_parser,
+    deep_update,
+    load_overrides_layered,
+)
+from .schema import V50ConfigSchema, get_json_schema
+from .schema_validator import validate_config
+from .symbolic_hooks import inject_symbolic_constraints
+from .validators import validate_config as validate_config_pydantic
 
 __all__ = [
     # Exceptions
@@ -48,9 +51,17 @@ __all__ = [
     "LOG_JSONL",
     "V50_DEBUG_LOG",
     "load_config_hydra",
+    "load_config",
+    "save_config",
     "validate_config",
+    "validate_config_pydantic",
     "apply_symbolic_overrides",
     "deep_update",
+    "cli_override_parser",
+    "apply_overrides",
     "load_overrides_layered",
+    "inject_symbolic_constraints",
+    "capture_environment",
+    "log_environment",
     "load_and_validate",
 ]

--- a/src/spectramind/conf_helpers/config_loader.py
+++ b/src/spectramind/conf_helpers/config_loader.py
@@ -1,0 +1,17 @@
+"""Basic YAML config loading and saving utilities."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def load_config(path: str | Path) -> DictConfig:
+    """Load a YAML configuration file into an ``OmegaConf`` ``DictConfig``."""
+    return OmegaConf.load(Path(path))
+
+
+def save_config(cfg: DictConfig, path: str | Path) -> None:
+    """Save a ``DictConfig`` to a YAML file."""
+    OmegaConf.save(cfg, Path(path))

--- a/src/spectramind/conf_helpers/env_capture.py
+++ b/src/spectramind/conf_helpers/env_capture.py
@@ -1,0 +1,27 @@
+"""Environment capture utilities."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+
+def capture_environment() -> Dict[str, Any]:
+    """Capture basic environment information."""
+    return {
+        "python_version": sys.version,
+        "platform": platform.platform(),
+        "env": dict(os.environ),
+    }
+
+
+def log_environment(path: str | Path) -> Dict[str, Any]:
+    """Capture environment information and persist it to ``path`` as JSON."""
+    data = capture_environment()
+    with open(Path(path), "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+    return data

--- a/src/spectramind/conf_helpers/overrides.py
+++ b/src/spectramind/conf_helpers/overrides.py
@@ -5,12 +5,13 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, Any, List, Union
-from omegaconf import OmegaConf, DictConfig
+from typing import Any, Dict, List, Union
 
-from .io import load_yaml
-from .logging_utils import write_md, log_event
+from omegaconf import DictConfig, OmegaConf
+
 from .exceptions import OverrideLoadError
+from .io import load_yaml
+from .logging_utils import log_event, write_md
 
 
 def deep_update(d: Dict[str, Any], u: Dict[str, Any]) -> Dict[str, Any]:
@@ -42,7 +43,10 @@ def apply_symbolic_overrides(
         merged = deep_update(base, ovr)
         return OmegaConf.create(merged) if isinstance(config, DictConfig) else merged
     except Exception as e:  # pragma: no cover - YAML issues
-        write_md("Apply override failed", {"error": str(e), "override_path": str(override_path)})
+        write_md(
+            "Apply override failed",
+            {"error": str(e), "override_path": str(override_path)},
+        )
         log_event("apply_override_error", {"error": str(e)})
         raise OverrideLoadError(str(e)) from e
 
@@ -56,3 +60,13 @@ def load_overrides_layered(
     for p in paths:
         out = apply_symbolic_overrides(out, p)
     return out
+
+
+def cli_override_parser(overrides: List[str]) -> DictConfig:
+    """Parse CLI-style ``key=value`` overrides into a ``DictConfig``."""
+    return OmegaConf.from_dotlist(overrides)
+
+
+def apply_overrides(cfg: DictConfig, overrides: DictConfig) -> DictConfig:
+    """Merge ``overrides`` into ``cfg`` returning a new ``DictConfig``."""
+    return OmegaConf.merge(cfg, overrides)

--- a/src/spectramind/conf_helpers/schema_validator.py
+++ b/src/spectramind/conf_helpers/schema_validator.py
@@ -1,0 +1,40 @@
+"""Validate configurations against a JSON schema."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Union
+
+from jsonschema import ValidationError, validate
+from omegaconf import DictConfig, OmegaConf
+
+
+def validate_config(
+    cfg: Union[Dict[str, Any], DictConfig], schema_path: str | Path
+) -> bool:
+    """Validate ``cfg`` against the JSON schema at ``schema_path``.
+
+    Parameters
+    ----------
+    cfg:
+        Configuration to validate. May be a plain ``dict`` or ``DictConfig``.
+    schema_path:
+        Path to a JSON schema file.
+
+    Returns
+    -------
+    bool
+        ``True`` if the config conforms to the schema, ``False`` otherwise.
+    """
+    if isinstance(cfg, DictConfig):
+        cfg = OmegaConf.to_container(cfg, resolve=True)  # type: ignore[assignment]
+
+    with open(Path(schema_path), "r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    try:
+        validate(instance=cfg, schema=schema)
+    except ValidationError:
+        return False
+    return True

--- a/src/spectramind/conf_helpers/symbolic_hooks.py
+++ b/src/spectramind/conf_helpers/symbolic_hooks.py
@@ -1,0 +1,16 @@
+"""Helpers for injecting default symbolic constraint weights."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from omegaconf import DictConfig, OmegaConf
+
+
+def inject_symbolic_constraints(cfg: DictConfig) -> DictConfig:
+    """Ensure a ``symbolic.constraints`` section exists with default weights."""
+    data: Dict[str, Any] = OmegaConf.to_container(cfg, resolve=True)  # type: ignore[assignment]
+    symbolic = data.setdefault("symbolic", {})
+    constraints = symbolic.setdefault("constraints", {})
+    constraints.setdefault("default_weight", 1.0)
+    return OmegaConf.create(data)

--- a/src/spectramind/conf_helpers/tests/test_config_loader.py
+++ b/src/spectramind/conf_helpers/tests/test_config_loader.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from omegaconf import OmegaConf
+
+from spectramind.conf_helpers import load_config, save_config
+
+
+def test_load_and_save(tmp_path):
+    cfg = OmegaConf.create({"a": 1})
+    path = tmp_path / "cfg.yaml"
+    save_config(cfg, path)
+    loaded = load_config(path)
+    assert loaded.a == 1

--- a/src/spectramind/conf_helpers/tests/test_env_capture.py
+++ b/src/spectramind/conf_helpers/tests/test_env_capture.py
@@ -1,0 +1,18 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from spectramind.conf_helpers import capture_environment, log_environment
+
+
+def test_capture_and_log(tmp_path):
+    env = capture_environment()
+    assert "python_version" in env
+    out = tmp_path / "env.json"
+    logged = log_environment(out)
+    assert out.exists()
+    with open(out, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    assert data["python_version"] == logged["python_version"]

--- a/src/spectramind/conf_helpers/tests/test_overrides.py
+++ b/src/spectramind/conf_helpers/tests/test_overrides.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from omegaconf import OmegaConf
+
+from spectramind.conf_helpers import apply_overrides, cli_override_parser
+
+
+def test_cli_overrides():
+    base = OmegaConf.create({"a": {"b": 1}})
+    overrides = cli_override_parser(["a.b=2", "c=3"])
+    merged = apply_overrides(base, overrides)
+    assert merged.a.b == 2
+    assert merged.c == 3

--- a/src/spectramind/conf_helpers/tests/test_schema_validator.py
+++ b/src/spectramind/conf_helpers/tests/test_schema_validator.py
@@ -1,0 +1,23 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from spectramind.conf_helpers import load_config, validate_config
+
+
+def test_validate_config(tmp_path):
+    cfg_yaml = tmp_path / "cfg.yaml"
+    schema_json = tmp_path / "schema.json"
+
+    cfg_yaml.write_text("a: 1\n", encoding="utf-8")
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "number"}},
+        "required": ["a"],
+    }
+    schema_json.write_text(json.dumps(schema), encoding="utf-8")
+
+    cfg = load_config(cfg_yaml)
+    assert validate_config(cfg, schema_json)


### PR DESCRIPTION
## Summary
- add config loader, schema validation, overrides and env capture helpers
- wire configuration utilities into `spectramind` CLI
- include basic tests for helpers

## Testing
- `pre-commit run --files spectramind.py src/spectramind/conf_helpers/__init__.py src/spectramind/conf_helpers/overrides.py src/spectramind/conf_helpers/config_loader.py src/spectramind/conf_helpers/schema_validator.py src/spectramind/conf_helpers/symbolic_hooks.py src/spectramind/conf_helpers/env_capture.py src/spectramind/conf_helpers/README.md src/spectramind/conf_helpers/tests/test_config_loader.py src/spectramind/conf_helpers/tests/test_overrides.py src/spectramind/conf_helpers/tests/test_schema_validator.py src/spectramind/conf_helpers/tests/test_env_capture.py`
- `pytest src/spectramind/conf_helpers/tests/test_config_loader.py src/spectramind/conf_helpers/tests/test_overrides.py src/spectramind/conf_helpers/tests/test_schema_validator.py src/spectramind/conf_helpers/tests/test_env_capture.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0d72a7760832aa50723eaa05450d5