### PR TITLE
fix: correct MSG_BODY quoting in kitchen sink push script

### DIFF
--- a/scripts/kitchen_sink_push.sh
+++ b/scripts/kitchen_sink_push.sh
@@ -225,7 +225,7 @@ fi
 
 DATE_UTC="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 MSG_HEADER="${COMMIT_TYPE}(${COMMIT_SCOPE}): kitchen-sink push — format/lint/tests/selftest wiring"
-MSG_BODY=$'\n'-" ci:selftest: deep wired; conf_helpers/tests included"$'\n'-" config_hash: ${CONFIG_HASH}"$'\n'-" datetime_utc: ${DATE_UTC}"$'\n'-" branch: ${TARGET_BRANCH}"
+MSG_BODY=$'\n'"- ci:selftest: deep wired; conf_helpers/tests included"$'\n'"- config_hash: ${CONFIG_HASH}"$'\n'"- datetime_utc: ${DATE_UTC}"$'\n'"- branch: ${TARGET_BRANCH}"
 
 echo
 echo "Committing…"


### PR DESCRIPTION
## Summary
- fix `MSG_BODY` assignment so bullet points are quoted correctly in kitchen sink push script

## Testing
- `pre-commit run --files scripts/kitchen_sink_push.sh`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a0df0c7990832a802f4d4fcd7b0422