### PR TITLE
Add SpectraMind CLI test suite

### DIFF
--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,1 @@
+# Marker for the tests.cli package.

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""
+Shared pytest fixtures for SpectraMind CLI tests.
+
+These fixtures provide a Typer `CliRunner`, isolate the working directory to a
+temporary path and seed minimal repository files expected by some commands.
+Environment variables are also adjusted so telemetry and logging output stay
+within the temporary directory used for each test.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+import pytest
+from typer.testing import CliRunner
+
+# Ensure the project's `src` directory is importable when tests are executed
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.fixture(scope="session")
+def runner() -> CliRunner:
+    """Return a Typer CliRunner instance for invoking commands."""
+    return CliRunner()
+
+
+@pytest.fixture
+def monkeypatch_cwd_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Change the working directory to a temporary path for the test."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture
+def env_test_mode(monkeypatch: pytest.MonkeyPatch) -> bool:
+    """Set common environment variables so the CLI behaves in test mode."""
+    monkeypatch.setenv("SPECTRAMIND_TEST", "1")
+    monkeypatch.setenv("SPECTRAMIND_DRYRUN_DEFAULT", "1")
+    monkeypatch.setenv("HYDRA_FULL_ERROR", "1")
+    # Keep telemetry and log artifacts local to the current working directory
+    monkeypatch.setenv("SPECTRAMIND_LOG_DIR", ".")
+    return True
+
+
+@pytest.fixture
+def repo_tmp_files(monkeypatch_cwd_tmp: Path) -> bool:
+    """Seed minimal files some commands expect to exist."""
+    Path("v50_debug_log.md").write_text(
+        "# SpectraMind V50 Debug Log\n"
+        "2025-08-16T12:00:00Z | CLI=1.0.0 | config_hash=deadbeef | cmd='spectramind --version'\n"
+    )
+    Path("run_hash_summary_v50.json").write_text(
+        json.dumps(
+            {
+                "config_hash": "deadbeef",
+                "build_timestamp": "2025-08-16T12:00:00Z",
+                "cli_version": "1.0.0",
+            },
+            indent=2,
+        )
+    )
+    return True
+
+
+@pytest.fixture
+def json_tmp_path_factory(tmp_path: Path) -> Callable[[str], Path]:
+    """Return a factory that builds output paths within `tmp_path`."""
+    def factory(name: str) -> Path:
+        out = tmp_path / name
+        out.parent.mkdir(parents=True, exist_ok=True)
+        return out
+
+    return factory

--- a/tests/cli/test_ablate_cli.py
+++ b/tests/cli/test_ablate_cli.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ablate CLI module."""
+import importlib
+
+from typer.testing import CliRunner
+
+
+def test_ablate_help(runner: CliRunner, env_test_mode, repo_tmp_files):
+    app_mod = importlib.import_module("spectramind.cli.cli_ablate")
+    app = getattr(app_mod, "app", None)
+    assert app is not None
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, f"ablate --help failed: {result.stdout}\n{result.stderr}"
+    for token in ["--top-n", "--md", "--open-html"]:
+        assert token in result.stdout or token.replace("-", "_") in result.stdout

--- a/tests/cli/test_core_v50_cli.py
+++ b/tests/cli/test_core_v50_cli.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Tests for the core-v50 CLI module."""
+import importlib
+
+from typer.testing import CliRunner
+
+
+def test_core_v50_help(runner: CliRunner, env_test_mode, repo_tmp_files):
+    app_mod = importlib.import_module("spectramind.cli.cli_core_v50")
+    app = getattr(app_mod, "app", None)
+    assert app is not None
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, f"core-v50 --help failed: {result.stdout}\n{result.stderr}"
+    for token in ["train", "predict", "calibrate"]:
+        assert token in result.stdout

--- a/tests/cli/test_diagnose_cli.py
+++ b/tests/cli/test_diagnose_cli.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+"""Tests for the diagnose CLI module."""
+import importlib
+
+from typer.testing import CliRunner
+
+
+def test_diagnose_help(runner: CliRunner, env_test_mode, repo_tmp_files):
+    app_mod = importlib.import_module("spectramind.cli.cli_diagnose")
+    app = getattr(app_mod, "app", None)
+    assert app is not None
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, f"diagnose --help failed: {result.stdout}\n{result.stderr}"
+    for token in ["dashboard", "symbolic-rank"]:
+        assert token in result.stdout

--- a/tests/cli/test_guardrails.py
+++ b/tests/cli/test_guardrails.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Tests for guardrail utilities used by CLI commands."""
+import pytest
+
+from spectramind.cli.cli_guardrails import confirm_guard, dry_run_guard
+
+
+def test_dry_run_guard(monkeypatch):
+    called = {"ran": False}
+
+    def action():
+        called["ran"] = True
+        return 42
+
+    guarded = dry_run_guard(action)
+    # When dry_run=True the wrapped function should not execute and return 0
+    assert guarded(dry_run=True) == 0
+    assert called["ran"] is False
+
+    # With dry_run=False the action should run and return its value
+    assert guarded(dry_run=False) == 42
+    assert called["ran"] is True
+
+
+def test_confirm_guard(monkeypatch):
+    called = {"ran": False}
+
+    def action():
+        called["ran"] = True
+        return 1
+
+    guarded = confirm_guard(prompt="?")(action)
+
+    # Auto-confirm via environment variable
+    monkeypatch.setenv("SPECTRAMIND_CONFIRM", "yes")
+    assert guarded(confirm=False) == 1
+    assert called["ran"] is True
+
+    # When user declines, the guard should exit before running action
+    called["ran"] = False
+    monkeypatch.setenv("SPECTRAMIND_CONFIRM", "")
+    monkeypatch.setattr("builtins.input", lambda *a, **k: "n")
+    with pytest.raises(SystemExit):
+        guarded(confirm=False)
+    assert called["ran"] is False

--- a/tests/cli/test_root_cli.py
+++ b/tests/cli/test_root_cli.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Tests for the top-level SpectraMind CLI application."""
+from typer.testing import CliRunner
+
+from .test_cli_root import _import_cli
+
+
+def test_root_cli_help(runner: CliRunner, env_test_mode, repo_tmp_files, tmp_path, monkeypatch):
+    cli = _import_cli(monkeypatch, tmp_path)
+    result = runner.invoke(cli.app, ["--help"])
+    assert result.exit_code == 0, f"--help failed: {result.stdout}\n{result.stderr}"
+    for token in ["version", "test", "diagnose-log"]:
+        assert token in result.stdout
+
+
+def test_root_cli_version_command(runner: CliRunner, env_test_mode, repo_tmp_files, tmp_path, monkeypatch):
+    cli = _import_cli(monkeypatch, tmp_path)
+    result = runner.invoke(cli.app, ["version"])
+    assert result.exit_code == 0
+    assert "cli_version" in result.stdout

--- a/tests/cli/test_selftest_cli.py
+++ b/tests/cli/test_selftest_cli.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+"""Tests for invoking the built-in self-test command."""
+from typer.testing import CliRunner
+
+from .test_cli_root import _import_cli
+
+
+def test_selftest_fast(runner: CliRunner, env_test_mode, repo_tmp_files, tmp_path, monkeypatch):
+    cli = _import_cli(monkeypatch, tmp_path)
+    result = runner.invoke(cli.app, ["test", "--fast"])
+    if result.exit_code != 0:
+        result = runner.invoke(cli.app, ["test"])
+    assert result.exit_code == 0, f"selftest failed: {result.stdout}\n{result.stderr}"

--- a/tests/cli/test_submit_cli.py
+++ b/tests/cli/test_submit_cli.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+"""Tests for the submit CLI module."""
+import importlib
+
+from typer.testing import CliRunner
+
+
+def test_submit_help(runner: CliRunner, env_test_mode, repo_tmp_files):
+    app_mod = importlib.import_module("spectramind.cli.cli_submit")
+    app = getattr(app_mod, "app", None)
+    assert app is not None
+
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0, f"submit --help failed: {result.stdout}\n{result.stderr}"
+    assert "submission" in result.stdout.lower()


### PR DESCRIPTION
## Summary
- add shared CLI test fixtures and environment helpers
- exercise core, diagnose, submit and ablate CLI modules
- test guardrail utilities and root self-test/version commands

## Testing
- `pytest -q tests/cli`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a0eb95b190832aa927d3aecba03487